### PR TITLE
delete oci dependencies unused dependencies

### DIFF
--- a/discovery-client/build.gradle
+++ b/discovery-client/build.gradle
@@ -11,13 +11,11 @@ dependencies {
 
     compileOnly "io.micronaut:micronaut-management"
     // used by OracleCloudVaultConfigurationClient
-    compileOnly 'com.oracle.oci.sdk:oci-java-sdk-vault:1.36.5'
     compileOnly 'com.oracle.oci.sdk:oci-java-sdk-secrets:2.1.1'
     compileOnly 'com.oracle.oci.sdk:oci-java-sdk-common:2.3.0'
 
     testImplementation "org.testcontainers:spock:1.15.3"
-
-    testImplementation 'com.oracle.oci.sdk:oci-java-sdk-vault:1.36.5'
+    
     //overriding the old version brought in by oci-java-sdk-vault
     testImplementation "com.fasterxml.jackson.module:jackson-module-jaxb-annotations"
     testImplementation 'com.oracle.oci.sdk:oci-java-sdk-secrets:1.36.5'

--- a/discovery-client/build.gradle
+++ b/discovery-client/build.gradle
@@ -18,7 +18,6 @@ dependencies {
 
     //overriding the old version brought in by oci-java-sdk-vault
     testImplementation "com.fasterxml.jackson.module:jackson-module-jaxb-annotations"
-    testImplementation 'com.oracle.oci.sdk:oci-java-sdk-common:1.36.5'
 
     testImplementation "io.micronaut:micronaut-management"
     testImplementation "io.micronaut:micronaut-http-server-netty"

--- a/discovery-client/build.gradle
+++ b/discovery-client/build.gradle
@@ -10,14 +10,8 @@ dependencies {
     implementation "io.projectreactor:reactor-core"
 
     compileOnly "io.micronaut:micronaut-management"
-    // used by OracleCloudVaultConfigurationClient
-    compileOnly 'com.oracle.oci.sdk:oci-java-sdk-secrets:2.1.1'
-    compileOnly 'com.oracle.oci.sdk:oci-java-sdk-common:2.3.0'
 
     testImplementation "org.testcontainers:spock:1.15.3"
-
-    //overriding the old version brought in by oci-java-sdk-vault
-    testImplementation "com.fasterxml.jackson.module:jackson-module-jaxb-annotations"
 
     testImplementation "io.micronaut:micronaut-management"
     testImplementation "io.micronaut:micronaut-http-server-netty"

--- a/discovery-client/build.gradle
+++ b/discovery-client/build.gradle
@@ -15,10 +15,9 @@ dependencies {
     compileOnly 'com.oracle.oci.sdk:oci-java-sdk-common:2.3.0'
 
     testImplementation "org.testcontainers:spock:1.15.3"
-    
+
     //overriding the old version brought in by oci-java-sdk-vault
     testImplementation "com.fasterxml.jackson.module:jackson-module-jaxb-annotations"
-    testImplementation 'com.oracle.oci.sdk:oci-java-sdk-secrets:1.36.5'
     testImplementation 'com.oracle.oci.sdk:oci-java-sdk-common:1.36.5'
 
     testImplementation "io.micronaut:micronaut-management"

--- a/discovery-client/src/main/java/io/micronaut/discovery/client/config/DistributedPropertySourceLocator.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/client/config/DistributedPropertySourceLocator.java
@@ -29,7 +29,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
 
-import javax.inject.Singleton;
+import jakarta.inject.Singleton;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.TimeoutException;

--- a/discovery-client/src/main/java/io/micronaut/discovery/consul/ConsulConfiguration.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/consul/ConsulConfiguration.java
@@ -28,7 +28,7 @@ import io.micronaut.discovery.registration.RegistrationConfiguration;
 import io.micronaut.http.HttpMethod;
 import io.micronaut.runtime.ApplicationConfiguration;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.List;

--- a/discovery-client/src/main/java/io/micronaut/discovery/consul/ConsulServiceInstanceList.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/consul/ConsulServiceInstanceList.java
@@ -21,7 +21,7 @@ import io.micronaut.discovery.consul.client.v1.ConsulClient;
 import io.micronaut.discovery.consul.condition.RequiresConsul;
 import io.micronaut.runtime.ApplicationConfiguration;
 
-import javax.inject.Singleton;
+import jakarta.inject.Singleton;
 
 /**
  * <p>A {@link io.micronaut.discovery.ServiceInstanceList} for Consul which reads from the

--- a/discovery-client/src/main/java/io/micronaut/discovery/consul/client/v1/AbstractConsulClient.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/consul/client/v1/AbstractConsulClient.java
@@ -26,7 +26,7 @@ import io.micronaut.discovery.consul.ConsulServiceInstance;
 import io.micronaut.http.client.annotation.Client;
 import org.reactivestreams.Publisher;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;

--- a/discovery-client/src/main/java/io/micronaut/discovery/eureka/EurekaServiceInstanceList.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/eureka/EurekaServiceInstanceList.java
@@ -20,8 +20,8 @@ import io.micronaut.discovery.eureka.client.v2.EurekaClient;
 import io.micronaut.discovery.eureka.condition.RequiresEureka;
 import io.micronaut.runtime.ApplicationConfiguration;
 
-import javax.inject.Inject;
-import javax.inject.Singleton;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
 
 /**
  * <p>A {@link io.micronaut.discovery.ServiceInstanceList} for Consul which reads from the {@link EurekaConfiguration}.</p>

--- a/discovery-client/src/main/java/io/micronaut/discovery/spring/config/SpringCloudClientConfiguration.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/spring/config/SpringCloudClientConfiguration.java
@@ -24,7 +24,7 @@ import io.micronaut.discovery.config.ConfigDiscoveryConfiguration;
 import io.micronaut.http.client.HttpClientConfiguration;
 import io.micronaut.runtime.ApplicationConfiguration;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.util.Optional;
 
 /**

--- a/discovery-client/src/main/java/io/micronaut/discovery/spring/config/client/ConfigServerPropertySource.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/spring/config/client/ConfigServerPropertySource.java
@@ -19,8 +19,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
-
-import javax.annotation.concurrent.Immutable;
 import java.util.Collections;
 import java.util.Map;
 
@@ -30,7 +28,6 @@ import java.util.Map;
  *  @author Thiago Locatelli
  *  @since 1.1.0
  */
-@Immutable
 public class ConfigServerPropertySource {
 
     private final String name;

--- a/discovery-client/src/main/java/io/micronaut/discovery/vault/config/AbstractVaultResponse.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/vault/config/AbstractVaultResponse.java
@@ -19,7 +19,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.micronaut.core.annotation.Introspected;
 
-import javax.annotation.concurrent.Immutable;
 import java.util.List;
 import java.util.Map;
 
@@ -31,7 +30,6 @@ import java.util.Map;
  *  @author thiagolocatelli
  *  @since 1.2.0
  */
-@Immutable
 @Introspected
 public abstract class AbstractVaultResponse<T> {
 

--- a/discovery-client/src/main/java/io/micronaut/discovery/vault/config/VaultClientConfiguration.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/vault/config/VaultClientConfiguration.java
@@ -22,7 +22,7 @@ import io.micronaut.discovery.config.ConfigDiscoveryConfiguration;
 import io.micronaut.http.client.HttpClientConfiguration;
 import io.micronaut.runtime.ApplicationConfiguration;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 /**
  *  A {@link HttpClientConfiguration} for Vault Client.

--- a/discovery-client/src/main/java/io/micronaut/discovery/vault/config/v1/VaultResponseV1.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/vault/config/v1/VaultResponseV1.java
@@ -21,7 +21,6 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.Introspected;
 import io.micronaut.discovery.vault.config.AbstractVaultResponse;
 
-import javax.annotation.concurrent.Immutable;
 import java.util.List;
 import java.util.Map;
 
@@ -31,7 +30,6 @@ import java.util.Map;
  *  @author thiagolocatelli
  *  @since 1.2.0
  */
-@Immutable
 @Introspected
 public class VaultResponseV1 extends AbstractVaultResponse<Map<String, Object>> {
 

--- a/discovery-client/src/main/java/io/micronaut/discovery/vault/config/v2/VaultResponseData.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/vault/config/v2/VaultResponseData.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.Introspected;
 
-import javax.annotation.concurrent.Immutable;
 import java.util.Collections;
 import java.util.Map;
 
@@ -30,7 +29,6 @@ import java.util.Map;
  *  @author thiagolocatelli
  *  @since 1.2.0
  */
-@Immutable
 @Introspected
 public class VaultResponseData {
 

--- a/discovery-client/src/main/java/io/micronaut/discovery/vault/config/v2/VaultResponseV2.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/vault/config/v2/VaultResponseV2.java
@@ -21,7 +21,6 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.Introspected;
 import io.micronaut.discovery.vault.config.AbstractVaultResponse;
 
-import javax.annotation.concurrent.Immutable;
 import java.util.List;
 import java.util.Map;
 
@@ -31,7 +30,6 @@ import java.util.Map;
  *  @author thiagolocatelli
  *  @since 1.2.0
  */
-@Immutable
 @Introspected
 public class VaultResponseV2 extends AbstractVaultResponse<VaultResponseData> {
 

--- a/discovery-client/src/test/groovy/io/micronaut/discovery/composite/CompositeDiscoverySpec.groovy
+++ b/discovery-client/src/test/groovy/io/micronaut/discovery/composite/CompositeDiscoverySpec.groovy
@@ -14,7 +14,7 @@ import spock.lang.Shared
 import spock.lang.Specification
 import spock.util.concurrent.PollingConditions
 
-import javax.inject.Singleton
+import jakarta.inject.Singleton
 
 class CompositeDiscoverySpec extends Specification {
 

--- a/discovery-client/src/test/groovy/io/micronaut/discovery/consul/ClientScopeSpec.groovy
+++ b/discovery-client/src/test/groovy/io/micronaut/discovery/consul/ClientScopeSpec.groovy
@@ -24,7 +24,7 @@ import io.micronaut.runtime.server.EmbeddedServer
 import spock.lang.IgnoreIf
 import spock.lang.Specification
 
-import javax.inject.Inject
+import jakarta.inject.Inject
 
 /**
  * @author graemerocher


### PR DESCRIPTION
oracle cloud code was removed by @jameskleeh here: https://github.com/micronaut-projects/micronaut-discovery-client/commit/a31ed53ec1890f820c83f87aa47b7e9b9f3209e6 It seems to be now on its own module: https://github.com/micronaut-projects/micronaut-oracle-cloud/pull/224/files

This PR also:

- replaces `javax.inject` with `jakarta.inject`
- deletes `@Immutable`