### PR TITLE
Made Spring Cloud Config response classes acessible reflectively

### DIFF
--- a/discovery-client/src/main/java/io/micronaut/discovery/spring/config/client/ConfigServerPropertySource.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/spring/config/client/ConfigServerPropertySource.java
@@ -19,6 +19,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.ReflectiveAccess;
+
 import java.util.Collections;
 import java.util.Map;
 
@@ -28,6 +30,7 @@ import java.util.Map;
  *  @author Thiago Locatelli
  *  @since 1.1.0
  */
+@ReflectiveAccess
 public class ConfigServerPropertySource {
 
     private final String name;

--- a/discovery-client/src/main/java/io/micronaut/discovery/spring/config/client/ConfigServerResponse.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/spring/config/client/ConfigServerResponse.java
@@ -15,6 +15,8 @@
  */
 package io.micronaut.discovery.spring.config.client;
 
+import io.micronaut.core.annotation.ReflectiveAccess;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -25,6 +27,7 @@ import java.util.List;
  *  @author Thiago Locatelli
  *  @since 1.0
  */
+@ReflectiveAccess
 public class ConfigServerResponse {
 
     private String name;


### PR DESCRIPTION
A path for issue #334 

Adding `@ReflectiveAccess` to `ConfigServerPropertySource` allows Jackson to use reflection while populating members of `ConfigServerResponse`.