### PR TITLE
[discovery-client] Spring cloud client basic authentication support

### DIFF
--- a/discovery-client/src/main/java/io/micronaut/discovery/spring/config/SpringCloudClientConfiguration.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/spring/config/SpringCloudClientConfiguration.java
@@ -50,6 +50,8 @@ public class SpringCloudClientConfiguration extends HttpClientConfiguration {
     private String label;
     private boolean failFast = DEFAULT_FAIL_FAST;
     private String name;
+    private String username;
+    private String password;
 
     private final SpringCloudConnectionPoolConfiguration springCloudConnectionPoolConfiguration;
     private final SpringConfigDiscoveryConfiguration springConfigDiscoveryConfiguration = new SpringConfigDiscoveryConfiguration();
@@ -114,6 +116,20 @@ public class SpringCloudClientConfiguration extends HttpClientConfiguration {
     }
 
     /**
+     * @return The spring cloud config username.
+     */
+    public Optional<String> getUsername() {
+        return username != null ? Optional.of(username) : Optional.empty();
+    }
+
+    /**
+     * @return The spring cloud config password.
+     */
+    public Optional<String> getPassword() {
+        return password != null ? Optional.of(password) : Optional.empty();
+    }
+
+    /**
      *
      * @return Flag to indicate that failure to connect to Spring Cloud Config is fatal (default false).
      */
@@ -148,6 +164,24 @@ public class SpringCloudClientConfiguration extends HttpClientConfiguration {
      */
     public void setName(String name) {
         this.name = name;
+    }
+
+    /**
+     * Set the Spring cloud config username.
+     *
+     * @param username Spring Cloud config username
+     */
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    /**
+     * Set the Spring cloud config password.
+     *
+     * @param password Spring Cloud config password
+     */
+    public void setPassword(String password) {
+        this.password = password;
     }
 
     /**

--- a/discovery-client/src/main/java/io/micronaut/discovery/spring/config/SpringCloudClientConfiguration.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/spring/config/SpringCloudClientConfiguration.java
@@ -19,6 +19,7 @@ import io.micronaut.context.annotation.BootstrapContextCompatible;
 import io.micronaut.context.annotation.ConfigurationProperties;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.discovery.config.ConfigDiscoveryConfiguration;
 import io.micronaut.http.client.HttpClientConfiguration;
@@ -119,14 +120,14 @@ public class SpringCloudClientConfiguration extends HttpClientConfiguration {
      * @return The spring cloud config username.
      */
     public Optional<String> getUsername() {
-        return username != null ? Optional.of(username) : Optional.empty();
+        return Optional.ofNullable(username);
     }
 
     /**
      * @return The spring cloud config password.
      */
     public Optional<String> getPassword() {
-        return password != null ? Optional.of(password) : Optional.empty();
+        return Optional.ofNullable(password);
     }
 
     /**
@@ -171,7 +172,7 @@ public class SpringCloudClientConfiguration extends HttpClientConfiguration {
      *
      * @param username Spring Cloud config username
      */
-    public void setUsername(String username) {
+    public void setUsername(@Nullable String username) {
         this.username = username;
     }
 
@@ -180,7 +181,7 @@ public class SpringCloudClientConfiguration extends HttpClientConfiguration {
      *
      * @param password Spring Cloud config password
      */
-    public void setPassword(String password) {
+    public void setPassword(@Nullable String password) {
         this.password = password;
     }
 

--- a/discovery-client/src/main/java/io/micronaut/discovery/spring/config/SpringCloudConfigurationClient.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/spring/config/SpringCloudConfigurationClient.java
@@ -101,12 +101,21 @@ public class SpringCloudConfigurationClient implements ConfigurationClient {
             }
 
             String authorization = getAuthorization(springCloudConfiguration);
+            Publisher<ConfigServerResponse> responsePublisher;
 
-            Publisher<ConfigServerResponse> responsePublisher =
+            if (authorization == null) {
+                responsePublisher =
                     springCloudConfiguration.getLabel() == null ?
-                    springCloudConfigClient.readValues(applicationName, profiles, authorization) :
-                    springCloudConfigClient.readValues(applicationName,
+                        springCloudConfigClient.readValues(applicationName, profiles) :
+                        springCloudConfigClient.readValues(applicationName,
+                            profiles, springCloudConfiguration.getLabel());
+            } else {
+                responsePublisher =
+                    springCloudConfiguration.getLabel() == null ?
+                        springCloudConfigClient.readValuesAuthorized(applicationName, profiles, authorization) :
+                        springCloudConfigClient.readValuesAuthorized(applicationName,
                             profiles, springCloudConfiguration.getLabel(), authorization);
+            }
 
             Flux<PropertySource> configurationValues = Flux.from(responsePublisher)
                     .onErrorResume(throwable -> {

--- a/discovery-client/src/main/java/io/micronaut/discovery/spring/config/client/SpringCloudConfigClient.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/spring/config/client/SpringCloudConfigClient.java
@@ -45,7 +45,24 @@ public interface SpringCloudConfigClient {
      *
      * @param applicationName   The application name
      * @param profiles          The active profiles
-     * @param authorization     The Basic authorization header if provided
+     * @return A {@link Publisher} that emits a list of {@link ConfigServerResponse}
+     */
+    @Get("/{applicationName}{/profiles}")
+    @Produces(single = true)
+    @Retryable(
+        attempts = "${" + SpringCloudClientConfiguration.SpringConfigDiscoveryConfiguration.PREFIX + ".retry-count:3}",
+        delay = "${" + SpringCloudClientConfiguration.SpringConfigDiscoveryConfiguration.PREFIX + ".retry-delay:1s}"
+    )
+    Publisher<ConfigServerResponse> readValues(
+        @NonNull String applicationName,
+        @Nullable String profiles);
+
+    /**
+     * Reads an application configuration from Spring Config Server with authorization parameter.
+     *
+     * @param applicationName   The application name
+     * @param profiles          The active profiles
+     * @param authorization     The Basic authorization header needed to authorize against the server
      * @return A {@link Publisher} that emits a list of {@link ConfigServerResponse}
      */
     @Get("/{applicationName}{/profiles}")
@@ -54,10 +71,10 @@ public interface SpringCloudConfigClient {
             attempts = "${" + SpringCloudClientConfiguration.SpringConfigDiscoveryConfiguration.PREFIX + ".retry-count:3}",
             delay = "${" + SpringCloudClientConfiguration.SpringConfigDiscoveryConfiguration.PREFIX + ".retry-delay:1s}"
     )
-    Publisher<ConfigServerResponse> readValues(
+    Publisher<ConfigServerResponse> readValuesAuthorized(
             @NonNull String applicationName,
             @Nullable String profiles,
-            @Nullable @Header String authorization);
+            @Header String authorization);
 
     /**
      * Reads a versioned (#label) application configuration from Spring Config Server.
@@ -65,7 +82,26 @@ public interface SpringCloudConfigClient {
      * @param applicationName   The application name
      * @param profiles          The active profiles
      * @param label             The label
-     * @param authorization     The Basic authorization header if provided
+     * @return A {@link Publisher} that emits a list of {@link ConfigServerResponse}
+     */
+    @Get("/{applicationName}{/profiles}{/label}")
+    @Produces(single = true)
+    @Retryable(
+        attempts = "${" + SpringCloudClientConfiguration.SpringConfigDiscoveryConfiguration.PREFIX + ".retry-count:3}",
+        delay = "${" + SpringCloudClientConfiguration.SpringConfigDiscoveryConfiguration.PREFIX + ".retry-delay:1s}"
+    )
+    Publisher<ConfigServerResponse> readValues(
+        @NonNull String applicationName,
+        @Nullable String profiles,
+        @Nullable String label);
+
+    /**
+     * Reads a versioned (#label) application configuration from Spring Config Server with authorization parameter.
+     *
+     * @param applicationName   The application name
+     * @param profiles          The active profiles
+     * @param label             The label
+     * @param authorization     The Basic authorization header needed to authorize against the server
      * @return A {@link Publisher} that emits a list of {@link ConfigServerResponse}
      */
     @Get("/{applicationName}{/profiles}{/label}")
@@ -74,10 +110,10 @@ public interface SpringCloudConfigClient {
             attempts = "${" + SpringCloudClientConfiguration.SpringConfigDiscoveryConfiguration.PREFIX + ".retry-count:3}",
             delay = "${" + SpringCloudClientConfiguration.SpringConfigDiscoveryConfiguration.PREFIX + ".retry-delay:1s}"
     )
-    Publisher<ConfigServerResponse> readValues(
+    Publisher<ConfigServerResponse> readValuesAuthorized(
             @NonNull String applicationName,
             @Nullable String profiles,
             @Nullable String label,
-            @Nullable @Header String authorization);
+            @Header String authorization);
 
 }

--- a/discovery-client/src/main/java/io/micronaut/discovery/spring/config/client/SpringCloudConfigClient.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/spring/config/client/SpringCloudConfigClient.java
@@ -21,6 +21,7 @@ import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.discovery.spring.config.SpringCloudClientConfiguration;
 import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.Header;
 import io.micronaut.http.annotation.Produces;
 import io.micronaut.http.client.annotation.Client;
 import io.micronaut.retry.annotation.Retryable;
@@ -44,6 +45,7 @@ public interface SpringCloudConfigClient {
      *
      * @param applicationName   The application name
      * @param profiles          The active profiles
+     * @param authorization     The Basic authorization header if provided
      * @return A {@link Publisher} that emits a list of {@link ConfigServerResponse}
      */
     @Get("/{applicationName}{/profiles}")
@@ -54,7 +56,8 @@ public interface SpringCloudConfigClient {
     )
     Publisher<ConfigServerResponse> readValues(
             @NonNull String applicationName,
-            @Nullable String profiles);
+            @Nullable String profiles,
+            @Nullable @Header String authorization);
 
     /**
      * Reads a versioned (#label) application configuration from Spring Config Server.
@@ -62,6 +65,7 @@ public interface SpringCloudConfigClient {
      * @param applicationName   The application name
      * @param profiles          The active profiles
      * @param label             The label
+     * @param authorization     The Basic authorization header if provided
      * @return A {@link Publisher} that emits a list of {@link ConfigServerResponse}
      */
     @Get("/{applicationName}{/profiles}{/label}")
@@ -73,6 +77,7 @@ public interface SpringCloudConfigClient {
     Publisher<ConfigServerResponse> readValues(
             @NonNull String applicationName,
             @Nullable String profiles,
-            @Nullable String label);
+            @Nullable String label,
+            @Nullable @Header String authorization);
 
 }

--- a/discovery-client/src/test/groovy/io/micronaut/discovery/spring/MockSpringCloudConfigSecuredServer.java
+++ b/discovery-client/src/test/groovy/io/micronaut/discovery/spring/MockSpringCloudConfigSecuredServer.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.discovery.spring;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.async.publisher.Publishers;
+import io.micronaut.discovery.spring.config.client.ConfigServerPropertySource;
+import io.micronaut.discovery.spring.config.client.ConfigServerResponse;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.Header;
+import io.micronaut.http.annotation.Produces;
+import io.micronaut.http.client.exceptions.HttpClientResponseException;
+import io.micronaut.http.simple.SimpleHttpResponseFactory;
+import org.reactivestreams.Publisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Mock cloud config server with simple Basic authentication implementation.
+ * It expects only username 'user' identified by password 'secured'.
+ */
+@Controller("/")
+@Requires(property = MockSpringCloudConfigSecuredServer.ENABLED)
+public class MockSpringCloudConfigSecuredServer extends MockSpringCloudConfigServer {
+
+    public static final String ENABLED = "enable.mock.spring-cloud-config-secured";
+
+    @Override
+    protected Publisher<ConfigServerResponse> getConfigServerResponse(
+        String applicationName, String profiles, String label, String authorization) {
+
+        checkAuthorization(authorization);
+
+        return super.getConfigServerResponse(applicationName, profiles, label, authorization);
+
+    }
+
+    /**
+     * Checks if Basic authorization header is provided and valid.
+     * If not valid throws {@link HttpClientResponseException}.
+     * This is simplified way of implementing Basic authentication in the mock server for the test.
+     * @param authorization
+     */
+    private static void checkAuthorization(String authorization) {
+        if (authorization == null) {
+            throw new HttpClientResponseException("No authorization provided", new SimpleHttpResponseFactory().status(HttpStatus.UNAUTHORIZED));
+        }
+        if (!authorization.startsWith("Basic ")) {
+            throw new HttpClientResponseException("Invalid authorization", new SimpleHttpResponseFactory().status(HttpStatus.UNAUTHORIZED));
+        }
+        authorization = authorization.replace("Basic ", "");
+        String decoded = new String(Base64.getDecoder().decode(authorization));
+        String[] parts = decoded.split(":");
+        // For test purposes we simplify and expect given username and password
+        if (parts.length == 2 && "user".equals(parts[0]) && "secured".equals(parts[1])) {
+            return;
+        }
+        throw new HttpClientResponseException("Invalid user credentials", new SimpleHttpResponseFactory().status(HttpStatus.UNAUTHORIZED));
+    }
+}

--- a/discovery-client/src/test/groovy/io/micronaut/discovery/spring/MockSpringCloudConfigServer.java
+++ b/discovery-client/src/test/groovy/io/micronaut/discovery/spring/MockSpringCloudConfigServer.java
@@ -23,6 +23,7 @@ import io.micronaut.discovery.spring.config.client.ConfigServerPropertySource;
 import io.micronaut.discovery.spring.config.client.ConfigServerResponse;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.Header;
 import io.micronaut.http.annotation.Produces;
 import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
@@ -41,20 +42,22 @@ public class MockSpringCloudConfigServer {
     @Get("/{applicationName}{/profiles}")
     @Produces(single = true)
     public Publisher<ConfigServerResponse> readValues(@NonNull String applicationName,
-                                                      @Nullable String profiles) {
-        return getConfigServerResponse(applicationName, profiles, null);
+                                                      @Nullable String profiles,
+                                                      @Nullable @Header String authorization) {
+        return getConfigServerResponse(applicationName, profiles, null, authorization);
     }
 
     @Get("/{applicationName}{/profiles}{/label}")
     @Produces(single = true)
     public Publisher<ConfigServerResponse> readValues(@NonNull String applicationName,
                                                       @Nullable String profiles,
-                                                      @Nullable String label) {
-        return getConfigServerResponse(applicationName, profiles, label);
+                                                      @Nullable String label,
+                                                      @Nullable @Header String authorization) {
+        return getConfigServerResponse(applicationName, profiles, label, authorization);
     }
 
-    private Publisher<ConfigServerResponse> getConfigServerResponse(
-            String applicationName, String profiles, String label)
+    protected Publisher<ConfigServerResponse> getConfigServerResponse(
+            String applicationName, String profiles, String label, String authorization)
     {
         String[] profilesArray = profiles != null ? profiles.split(",") : new String[0];
         ConfigServerResponse configServerResponse = new ConfigServerResponse();

--- a/discovery-client/src/test/groovy/io/micronaut/discovery/spring/SpringCloudConfigSecuredTest.groovy
+++ b/discovery-client/src/test/groovy/io/micronaut/discovery/spring/SpringCloudConfigSecuredTest.groovy
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.discovery.spring
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.env.Environment
+import io.micronaut.context.exceptions.ConfigurationException
+import io.micronaut.discovery.vault.MockingVaultServerV1Controller
+import io.micronaut.http.client.exceptions.HttpClientResponseException
+import io.micronaut.runtime.server.EmbeddedServer
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.util.environment.RestoreSystemProperties
+
+/**
+ * Tests for getting properties from the secured cloud config server.
+ */
+@RestoreSystemProperties
+class SpringCloudConfigSecuredTest extends Specification {
+
+    @Shared
+    @AutoCleanup
+    EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, [(MockSpringCloudConfigSecuredServer.ENABLED): true])
+
+    void "test spring name configuration field when server secured and authorization provided"() {
+        given:
+        System.setProperty(Environment.BOOTSTRAP_CONTEXT_PROPERTY, "true")
+        ApplicationContext context = ApplicationContext.run([
+                (MockSpringCloudConfigServer.ENABLED): true,
+                "micronaut.application.name": "myapp",
+                "micronaut.config-client.enabled": true,
+                "spring.cloud.config.enabled": true,
+                "spring.cloud.config.name": "myapp-from-spring",
+                "spring.cloud.config.uri": embeddedServer.getURL().toString(),
+                "spring.cloud.config.username": "user",
+                "spring.cloud.config.password": "secured"
+        ], "first", "second")
+
+        expect:
+        "myapp-from-spring" == context.getRequiredProperty("app-name-from-spring-config", String.class)
+
+        cleanup:
+        context.stop()
+    }
+
+    void "test when cloud server secured and authorization not provided"() {
+        given:
+        System.setProperty(Environment.BOOTSTRAP_CONTEXT_PROPERTY, "true")
+
+        when:
+        ApplicationContext context = ApplicationContext.run([
+                (MockSpringCloudConfigServer.ENABLED): true,
+                "micronaut.application.name": "myapp",
+                "micronaut.config-client.enabled": true,
+                "spring.cloud.config.enabled": true,
+                "spring.cloud.config.name": "myapp-from-spring",
+                "spring.cloud.config.uri": embeddedServer.getURL().toString()
+        ], "first", "second")
+
+        then:
+        def e = thrown(ConfigurationException)
+        e.cause instanceof HttpClientResponseException
+
+        cleanup:
+        if (context != null) {
+            context.stop()
+        }
+    }
+
+    void "test when cloud server secured and only username is provided"() {
+        given:
+        System.setProperty(Environment.BOOTSTRAP_CONTEXT_PROPERTY, "true")
+
+        when:
+        ApplicationContext context = ApplicationContext.run([
+                (MockSpringCloudConfigServer.ENABLED): true,
+                "micronaut.application.name": "myapp",
+                "micronaut.config-client.enabled": true,
+                "spring.cloud.config.enabled": true,
+                "spring.cloud.config.name": "myapp-from-spring",
+                "spring.cloud.config.uri": embeddedServer.getURL().toString(),
+                "spring.cloud.config.username": "user",
+        ], "first", "second")
+
+        then:
+        def e = thrown(ConfigurationException)
+        e.cause instanceof HttpClientResponseException
+
+        cleanup:
+        if (context != null) {
+            context.stop()
+        }
+    }
+
+    void "test when cloud server secured and invalid user credentials provided"() {
+        given:
+        System.setProperty(Environment.BOOTSTRAP_CONTEXT_PROPERTY, "true")
+
+        when:
+        ApplicationContext context = ApplicationContext.run([
+                (MockSpringCloudConfigServer.ENABLED): true,
+                "micronaut.application.name": "myapp",
+                "micronaut.config-client.enabled": true,
+                "spring.cloud.config.enabled": true,
+                "spring.cloud.config.name": "myapp-from-spring",
+                "spring.cloud.config.uri": embeddedServer.getURL().toString(),
+                "spring.cloud.config.username": "user",
+                "spring.cloud.config.password": "nonsecured"
+        ], "first", "second")
+
+        then:
+        def e = thrown(ConfigurationException)
+        e.cause instanceof HttpClientResponseException
+
+        cleanup:
+        if (context != null) {
+            context.stop()
+        }
+    }
+
+}


### PR DESCRIPTION
Adding support for basic authentication configuration for spring cloud server.
Based on https://github.com/micronaut-projects/micronaut-discovery-client/issues/106 this is how I thought it could fixed.