### PR TITLE
Switch to http status check instead of reading the logs

### DIFF
--- a/test-suite-consul-graal/src/test/resources/application.yml
+++ b/test-suite-consul-graal/src/test/resources/application.yml
@@ -19,6 +19,6 @@ test-resources:
       exposed-ports:
         - consul.port: 8500
       wait-strategy:
-        log:
-          regex: ".*Node info in sync.*"
-          times: 2
+        http:
+          path: "/v1/status/leader"
+          status-code: 200


### PR DESCRIPTION
@graemerocher reported occasional network errors with the previous strategy.

This switches to making an http call to check there is an elected leader prior to running the tests