### PR TITLE
Fix resolveEnvironment method to get proper envName from fileName

### DIFF
--- a/discovery-client/src/main/java/io/micronaut/discovery/consul/config/ConsulConfigurationClient.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/consul/config/ConsulConfigurationClient.java
@@ -205,7 +205,7 @@ public class ConsulConfigurationClient implements ConfigurationClient {
                                             String finalName = propertySourceName;
                                             byte[] decoded = base64Decoder.decode(value);
                                             Map<String, Object> properties = propertySourceLoader.read(propertySourceName, decoded);
-                                            String envName = ClientUtil.resolveEnvironment(fileName, activeNames);
+                                            String envName = ClientUtil.resolveEnvironment(finalName, activeNames);
                                             LocalSource localSource = propertySources.computeIfAbsent(propertySourceName, s -> new LocalSource(isApplicationSpecificConfigKey, envName, finalName));
                                             localSource.putAll(properties);
                                         }


### PR DESCRIPTION
With the existing code, the value of the `envName` variable will never be resolved correctly because the `resolveEnvironment` method will get the value of the `fileName` variable.

For example: if the name of the configuration file is `my-service-prod.yaml` (where **prod** is the name of the environment) and we provide `fileName` as a parameter (_value is my-service-prod_) instead of `finalName` (_value is my-service[alpha]_), then `resolveEnvironment` method will not be able to find environment.

The effect is that consul will overwrite the environment configuration with the standard configuration (e.g. `my-service.yaml`), i.e. the environment configuration will not be considered appropriate.