### PR TITLE
[ConsulOperations] Make the recurse query configurable

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -45,7 +45,7 @@ jobs:
           fetch-depth: 0
 
       - name: "🔧 Setup GraalVM CE"
-        uses: graalvm/setup-graalvm@v1.2.1
+        uses: graalvm/setup-graalvm@v1.2.5
         with:
           distribution: 'graalvm'
           java-version: ${{ matrix.java }}

--- a/discovery-client/src/main/java/io/micronaut/discovery/consul/client/v1/ConsulOperations.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/consul/client/v1/ConsulOperations.java
@@ -16,6 +16,7 @@
 package io.micronaut.discovery.consul.client.v1;
 
 import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.async.publisher.Publishers;
 import io.micronaut.http.HttpStatus;
 import io.micronaut.http.MediaType;
 import io.micronaut.http.annotation.Body;
@@ -28,6 +29,7 @@ import org.reactivestreams.Publisher;
 
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 /**
  * API operations for Consul.
@@ -48,24 +50,39 @@ public interface ConsulOperations {
     Publisher<Boolean> putValue(String key, @Body String value);
 
     /**
-     * Reads a Key from Consul. See https://www.consul.io/api/kv.html.
+     * Reads a Key from Consul. It will return all KV matching key as prefix.
+     * See <a href="https://www.consul.io/api/kv.html">https://www.consul.io/api/kv.html</a>.
      *
-     * @param key The key to read
+     * @param key     The prefix to match
+     * @return A {@link Publisher} that emits a list of {@link KeyValue}
+     * @see #readValues(String, boolean)
+     */
+    default Publisher<List<KeyValue>> readValues(String key){
+        return readValues(key, true);
+    }
+
+    /**
+     * Reads a Key from Consul. See <a href="https://www.consul.io/api/kv.html">https://www.consul.io/api/kv.html</a>.
+     *
+     * @param key     The key to read
+     * @param recurse Specifies if the lookup should be recursive and treat key as a prefix instead of a literal match.
      * @return A {@link Publisher} that emits a list of {@link KeyValue}
      */
-    @Get(uri = "/kv/{+key}?recurse", single = true)
-    Publisher<List<KeyValue>> readValues(String key);
+    @Get(uri = "/kv/{+key}?{&recurse}", single = true)
+    Publisher<List<KeyValue>> readValues(String key,
+                                         @QueryValue boolean recurse);
 
     /**
      * Reads a Key from Consul. See https://www.consul.io/api/kv.html.
      *
      * @param key        The key
      * @param datacenter The data center
+     * @param recurse    Specifies if the lookup should be recursive and treat key as a prefix instead of a literal match.
      * @param raw        Whether the value should be raw without encoding or metadata
-     * @param seperator  The separator to use
+     * @param separator  The separator to use
      * @return A {@link Publisher} that emits a list of {@link KeyValue}
      */
-    @Get(uri = "/kv/{+key}?recurse=true{&dc}{&raw}{&seperator}", single = true)
+    @Get(uri = "/kv/{+key}?{&recurse}{&dc}{&raw}{&separator}", single = true)
     @Retryable(
         attempts = AbstractConsulClient.EXPR_CONSUL_CONFIG_RETRY_COUNT,
         delay = AbstractConsulClient.EXPR_CONSUL_CONFIG_RETRY_DELAY
@@ -73,8 +90,9 @@ public interface ConsulOperations {
     Publisher<List<KeyValue>> readValues(
         String key,
         @Nullable @QueryValue("dc") String datacenter,
+        @QueryValue boolean recurse,
         @Nullable Boolean raw,
-        @Nullable String seperator);
+        @Nullable String separator);
 
     /**
      * Pass the TTL check. See https://www.consul.io/api/agent/check.html.

--- a/discovery-client/src/main/java/io/micronaut/discovery/consul/config/ConsulConfigurationClient.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/consul/config/ConsulConfigurationClient.java
@@ -152,7 +152,7 @@ public class ConsulConfigurationClient implements ConfigurationClient {
         };
 
         Flux<List<KeyValue>> applicationConfig = Flux.from(
-                consulClient.readValues(commonConfigPath, dc, null, null))
+                consulClient.readValues(commonConfigPath, dc, true, null, null))
                 .onErrorResume(errorHandler);
         if (scheduler != null) {
             applicationConfig = applicationConfig.subscribeOn(scheduler);
@@ -161,7 +161,7 @@ public class ConsulConfigurationClient implements ConfigurationClient {
 
         if (hasApplicationSpecificConfig) {
             Flux<List<KeyValue>> appSpecificConfig = Flux.from(
-                    consulClient.readValues(applicationSpecificPath, dc, null, null))
+                    consulClient.readValues(applicationSpecificPath, dc, true, null, null))
                     .onErrorResume(errorHandler);
             if (scheduler != null) {
                 appSpecificConfig = appSpecificConfig.subscribeOn(scheduler);

--- a/discovery-client/src/test/groovy/io/micronaut/discovery/consul/ConsulMockConfigurationClientNativeSpec.groovy
+++ b/discovery-client/src/test/groovy/io/micronaut/discovery/consul/ConsulMockConfigurationClientNativeSpec.groovy
@@ -66,11 +66,16 @@ class ConsulMockConfigurationClientNativeSpec extends Specification {
 
         when:"Properties are read"
         Flux.from(client.putValue("config/application/datasource.driver", "java.SomeDriver")).blockFirst()
+        Flux.from(client.putValue("config/application,h2/datasource.driver", "h2.OtherDriver")).blockFirst()
 
-        List<KeyValue> keyValues = Flux.from(client.readValues("config")).blockFirst()
+        List<KeyValue> matchingKeyValues = Flux.from(client.readValues("config/application")).blockFirst()
+        List<KeyValue> exactKeyValues = Flux.from(client.readValues("config/application", false)).blockFirst()
 
         then:
-        keyValues.size() == 2
+        matchingKeyValues.size() == 3
+        matchingKeyValues.collect {it.key}.toSet() == Set.of("config/application/datasource.url", "config/application/datasource.driver", "config/application,h2/datasource.driver")
+        exactKeyValues.size() == 2
+        exactKeyValues.collect {it.key}.toSet() == Set.of("config/application/datasource.url", "config/application/datasource.driver")
     }
 
     void "test discovery property sources from Consul with native property handling"() {

--- a/discovery-client/src/test/groovy/io/micronaut/discovery/consul/MockConsulServer.groovy
+++ b/discovery-client/src/test/groovy/io/micronaut/discovery/consul/MockConsulServer.groovy
@@ -101,11 +101,11 @@ class MockConsulServer implements ConsulOperations {
     }
 
     @Override
-    @Get("/kv/{+key}")
     @SingleResult
-    Publisher<List<KeyValue>> readValues(String key) {
+    Publisher<List<KeyValue>> readValues(String key,
+                                         @QueryValue boolean recurse) {
         key = URLDecoder.decode(key, "UTF-8")
-        Map<String, List<KeyValue>> found = keyvalues.findAll { entry -> entry.key.startsWith(key)}
+        Map<String, List<KeyValue>> found = keyvalues.findAll { entry -> recurse ? entry.key.startsWith(key) : entry.key == key }
         if(found) {
             return Flux.just(found.values().stream().flatMap({ values -> values.stream() })
                                    .collect(Collectors.toList()))
@@ -128,8 +128,9 @@ class MockConsulServer implements ConsulOperations {
     @SingleResult
     Publisher<List<KeyValue>> readValues(String key,
                                         @Nullable @QueryValue("dc") String datacenter,
-                                        @Nullable Boolean raw, @Nullable String seperator) {
-        return readValues(key)
+                                        @QueryValue boolean recurse,
+                                        @Nullable Boolean raw, @Nullable String separator) {
+        return readValues(key, recurse)
     }
 
     @Override


### PR DESCRIPTION
Make the read KV operation more flexible by allowing the recurse parameter to be set to `true` or `false`