### PR TITLE
Add an optional watch to Consul

### DIFF
--- a/discovery-client/build.gradle
+++ b/discovery-client/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     testImplementation(mn.micronaut.management)
     testImplementation(mn.micronaut.http.server.netty)
     testImplementation(mn.snakeyaml)
+    testImplementation(mnLogging.logback.classic)
 
     testCompileOnly(mn.micronaut.inject.groovy)
 }

--- a/discovery-client/src/main/java/io/micronaut/discovery/consul/client/v1/ConsulAslTokenClientFilter.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/consul/client/v1/ConsulAslTokenClientFilter.java
@@ -35,7 +35,7 @@ import java.util.Optional;
 @ClientFilter(patterns = "/v1/**", serviceId = ConsulClient.SERVICE_ID)
 @Requires(beans = ConsulConfiguration.class)
 @BootstrapContextCompatible
-public class ConsulAslTokenClientFilter implements Toggleable {
+public final class ConsulAslTokenClientFilter implements Toggleable {
 
     /**
      * Consult header token.

--- a/discovery-client/src/main/java/io/micronaut/discovery/consul/client/v1/ConsulOperations.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/consul/client/v1/ConsulOperations.java
@@ -62,10 +62,10 @@ public interface ConsulOperations {
      * @param key        The key
      * @param datacenter The data center
      * @param raw        Whether the value should be raw without encoding or metadata
-     * @param seperator  The separator to use
+     * @param separator  The separator to use
      * @return A {@link Publisher} that emits a list of {@link KeyValue}
      */
-    @Get(uri = "/kv/{+key}?recurse=true{&dc}{&raw}{&seperator}", single = true)
+    @Get(uri = "/kv/{+key}?recurse=true{&dc}{&raw}{&separator}", single = true)
     @Retryable(
         attempts = AbstractConsulClient.EXPR_CONSUL_CONFIG_RETRY_COUNT,
         delay = AbstractConsulClient.EXPR_CONSUL_CONFIG_RETRY_DELAY
@@ -74,7 +74,7 @@ public interface ConsulOperations {
         String key,
         @Nullable @QueryValue("dc") String datacenter,
         @Nullable Boolean raw,
-        @Nullable String seperator);
+        @Nullable String separator);
 
     /**
      * Pass the TTL check. See https://www.consul.io/api/agent/check.html.

--- a/discovery-client/src/main/java/io/micronaut/discovery/consul/client/v1/KeyValue.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/consul/client/v1/KeyValue.java
@@ -19,6 +19,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.annotation.ReflectiveAccess;
 import io.micronaut.serde.annotation.Serdeable;
 
@@ -32,17 +34,28 @@ import io.micronaut.serde.annotation.Serdeable;
 @Serdeable
 @ReflectiveAccess
 public class KeyValue {
-    private String key;
-    private String value;
+
+    private final Integer modifyIndex;
+    private final String key;
+    private final String value;
 
     /**
+     * @param modifyIndex The KV index
      * @param key   The key
      * @param value The value
      */
     @JsonCreator
-    public KeyValue(@JsonProperty("Key") String key, @JsonProperty("Value") String value) {
+    public KeyValue(@Nullable @JsonProperty("ModifyIndex") Integer modifyIndex, @JsonProperty("Key") String key, @JsonProperty("Value") String value) {
+        this.modifyIndex = modifyIndex;
         this.key = key;
         this.value = value;
+    }
+
+    /**
+     * @return The modifyIndex
+     */
+    public Integer getModifyIndex() {
+        return modifyIndex;
     }
 
     /**

--- a/discovery-client/src/main/java/io/micronaut/discovery/consul/client/v1/blockingqueries/BlockedQueries.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/consul/client/v1/blockingqueries/BlockedQueries.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.discovery.consul.client.v1.blockingqueries;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import io.micronaut.http.annotation.FilterMatcher;
+
+/**
+ * Annotation to handle the {@code wait} parameter for <a href="https://developer.hashicorp.com/consul/api-docs/features/blocking">Consul Blocking Queries</a>.
+ *
+ * @author LE GALL Benoît
+ * @see BlockedQueryClientFilter
+ * @see BlockingQueriesConfiguration
+ * @since 4.6.0
+ */
+@FilterMatcher
+@Documented
+@Retention(RUNTIME)
+@Target({METHOD, TYPE})
+public @interface BlockedQueries {
+}

--- a/discovery-client/src/main/java/io/micronaut/discovery/consul/client/v1/blockingqueries/BlockedQueriesConsulClient.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/consul/client/v1/blockingqueries/BlockedQueriesConsulClient.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.discovery.consul.client.v1.blockingqueries;
+
+import java.util.List;
+
+import org.reactivestreams.Publisher;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.discovery.consul.client.v1.ConsulClient;
+import io.micronaut.discovery.consul.client.v1.KeyValue;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.QueryValue;
+import io.micronaut.http.client.annotation.Client;
+import reactor.core.publisher.Mono;
+
+/**
+ * A non-blocking HTTP client for Consul, using <a href="https://developer.hashicorp.com/consul/api-docs/features/blocking">Blocking Queries</a> feature
+ * to wait for potential changes using long polling.
+ *
+ * @author LE GALL Benoît
+ * @since 4.6.0
+ */
+@BlockedQueries
+@Requires(beans = BlockingQueriesConfiguration.class)
+@Client(id = ConsulClient.SERVICE_ID, path = "/v1",
+        configuration = BlockingQueriesConfiguration.class)
+public interface BlockedQueriesConsulClient {
+
+    /**
+     * Reads a Key from Consul. See <a href="https://developer.hashicorp.com/consul/api-docs/kv#read-key">KV Store - ReadKey API</a>.
+     *
+     * @param key     The key to watch
+     * @param recurse Whether the lookup is recursive or not. When {@code true}, treat {@code key} as a prefix
+     * @param index   The index value against which to wait for subsequent changes
+     * @return A {@link Publisher} that emits a list of {@link KeyValue}
+     */
+    @Get(uri = "/kv/{+key}?{&recurse}{&index}", single = true)
+    Mono<List<KeyValue>> watchValues(String key,
+                                     @Nullable @QueryValue Boolean recurse,
+                                     @Nullable @QueryValue Integer index);
+
+}

--- a/discovery-client/src/main/java/io/micronaut/discovery/consul/client/v1/blockingqueries/BlockedQueryClientFilter.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/consul/client/v1/blockingqueries/BlockedQueryClientFilter.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.discovery.consul.client.v1.blockingqueries;
+
+import jakarta.inject.Singleton;
+
+import io.micronaut.http.MutableHttpRequest;
+import io.micronaut.http.annotation.ClientFilter;
+import io.micronaut.http.annotation.RequestFilter;
+
+/**
+ * Filter to add the {@code wait} parameter for <a href="https://developer.hashicorp.com/consul/api-docs/features/blocking">Consul Blocking Queries</a> for request annotated with {@link BlockedQueries}.
+ *
+ * @author LE GALL Benoît
+ * @see BlockedQueries
+ * @see BlockingQueriesConfiguration
+ * @since 4.6.0
+ */
+@BlockedQueries
+@Singleton
+@ClientFilter
+public final class BlockedQueryClientFilter {
+
+    static final String PARAMETER_INDEX = "index";
+    static final String PARAMETER_WAIT = "wait";
+
+    private final BlockingQueriesConfiguration blockingQueriesConfiguration;
+
+    public BlockedQueryClientFilter(
+        final BlockingQueriesConfiguration blockingQueriesConfiguration) {
+        this.blockingQueriesConfiguration = blockingQueriesConfiguration;
+    }
+
+    @RequestFilter
+    void filterRequest(final MutableHttpRequest<?> request) {
+        final var parameters = request.getParameters();
+        if (parameters.contains(PARAMETER_INDEX)) {
+            parameters.add(PARAMETER_WAIT, blockingQueriesConfiguration.getMaxWaitDuration());
+        }
+    }
+}

--- a/discovery-client/src/main/java/io/micronaut/discovery/consul/client/v1/blockingqueries/BlockingQueriesConfiguration.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/consul/client/v1/blockingqueries/BlockingQueriesConfiguration.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.discovery.consul.client.v1.blockingqueries;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.convert.ConversionService;
+import io.micronaut.discovery.consul.ConsulConfiguration;
+import io.micronaut.discovery.consul.condition.RequiresConsul;
+import io.micronaut.http.client.HttpClientConfiguration;
+
+/**
+ * Configuration for <a href="https://developer.hashicorp.com/consul/api-docs/features/blocking">Consul Blocking Queries</a>.
+ *
+ * @author LE GALL Benoît
+ * @since 4.6.0
+ */
+@RequiresConsul
+@ConfigurationProperties(BlockingQueriesConfiguration.PREFIX)
+public class BlockingQueriesConfiguration extends HttpClientConfiguration {
+
+    /**
+     * The prefix to use for all Consul's blocked queries settings.
+     */
+    public static final String PREFIX = ConsulConfiguration.PREFIX + ".blocking-queries";
+
+    /**
+     * The default max wait duration in minutes.
+     */
+    public static final String DEFAULT_MAX_WAIT_DURATION_MINUTES = "10m";
+
+    /**
+     * The default delay duration in milliseconds.
+     */
+    public static final long DEFAULT_DELAY_DURATION_MILLISECONDS = 50;
+
+    private String maxWaitDuration = DEFAULT_MAX_WAIT_DURATION_MINUTES;
+    private Duration delayDuration = Duration.ofMillis(DEFAULT_DELAY_DURATION_MILLISECONDS);
+    private Duration readTimeout = null;
+
+    private final ConsulConfiguration consulConfiguration;
+    private final ConversionService conversionService;
+
+    /**
+     * Default constructor.
+     *
+     * @param consulConfiguration {@link ConsulConfiguration} used as base.
+     * @param conversionService   Use to calculate the {@link #readTimeout} from the {@link #maxWaitDuration}.
+     * @see ConsulConfiguration
+     */
+    public BlockingQueriesConfiguration(final ConsulConfiguration consulConfiguration,
+                                        final ConversionService conversionService) {
+        super(consulConfiguration);
+        this.consulConfiguration = consulConfiguration;
+        this.conversionService = conversionService;
+    }
+
+    @Override
+    public ConnectionPoolConfiguration getConnectionPoolConfiguration() {
+        return consulConfiguration.getConnectionPoolConfiguration();
+    }
+
+    /**
+     * @return The read timeout, depending on the {@link #maxWaitDuration} value.
+     */
+    @Override
+    public Optional<Duration> getReadTimeout() {
+        if (this.readTimeout == null) {
+            this.readTimeout = calculateReadTimeout();
+        }
+        return Optional.of(this.readTimeout);
+    }
+
+    private Duration calculateReadTimeout() {
+        final var waitValue = Optional.ofNullable(getMaxWaitDuration())
+            .orElse(DEFAULT_MAX_WAIT_DURATION_MINUTES);
+
+        final var duration = conversionService.convertRequired(waitValue, Duration.class);
+        // to have the client timeout greater than the wait of the Blocked Query
+        return duration.plusMillis(duration.toMillis() / 16);
+    }
+
+    /**
+     * @return The max wait duration. Defaults to {@value DEFAULT_MAX_WAIT_DURATION_MINUTES}.
+     */
+    @Nullable
+    public String getMaxWaitDuration() {
+        return this.maxWaitDuration;
+    }
+
+    /**
+     * Specify the maximum duration for the blocking request. Default value ({@value #DEFAULT_MAX_WAIT_DURATION_MINUTES}).
+     *
+     * @param maxWaitDuration The wait timeout
+     */
+    public void setMaxWaitDuration(@Nullable final String maxWaitDuration) {
+        this.maxWaitDuration = maxWaitDuration;
+        this.readTimeout = calculateReadTimeout();
+    }
+
+    /**
+     * @return The delay duration. Defaults to {@value DEFAULT_DELAY_DURATION_MILLISECONDS} milliseconds.
+     */
+    @NonNull
+    public Duration getDelayDuration() {
+        return this.delayDuration;
+    }
+
+    /**
+     * Sets the delay before each call to avoid flooding. Default value ({@value #DEFAULT_DELAY_DURATION_MILLISECONDS} milliseconds).
+     *
+     * @param delayDuration The watch delay
+     */
+    public void setDelayDuration(final Duration delayDuration) {
+        if (delayDuration == null) {
+            this.delayDuration = Duration.ofMillis(DEFAULT_DELAY_DURATION_MILLISECONDS);
+        } else {
+            this.delayDuration = delayDuration;
+        }
+    }
+}

--- a/discovery-client/src/main/java/io/micronaut/discovery/consul/client/v1/blockingqueries/package-info.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/consul/client/v1/blockingqueries/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Consul Blocked Queries Client classes.
+ * @since 4.6.0
+ */
+package io.micronaut.discovery.consul.client.v1.blockingqueries;

--- a/discovery-client/src/main/java/io/micronaut/discovery/consul/watch/AbstractWatcher.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/consul/watch/AbstractWatcher.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.discovery.consul.watch;
+
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.discovery.consul.client.v1.KeyValue;
+import io.micronaut.discovery.consul.client.v1.blockingqueries.BlockingQueriesConfiguration;
+import io.micronaut.discovery.consul.client.v1.blockingqueries.BlockedQueriesConsulClient;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.client.exceptions.HttpClientResponseException;
+import io.micronaut.http.client.exceptions.ReadTimeoutException;
+import reactor.core.Disposable;
+import reactor.core.publisher.Mono;
+
+/**
+ * @param <V> The type of KeyValue to watch
+ * @author LE GALL Benoît
+ * @since 4.6.0
+ */
+@Internal
+abstract sealed class AbstractWatcher<V> implements Watcher permits ConfigurationsWatcher, NativeWatcher {
+
+    protected static final Integer NO_INDEX = null;
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractWatcher.class);
+
+    protected final BlockedQueriesConsulClient consulClient;
+    protected final Map<String, V> kvHolder = new ConcurrentHashMap<>();
+
+    private final List<String> kvPaths;
+    private final BlockingQueriesConfiguration blockingQueriesConfiguration;
+    private final PropertiesChangeHandler propertiesChangeHandler;
+
+    private final Map<String, Disposable> listeners = new ConcurrentHashMap<>();
+
+    private final Base64.Decoder base64Decoder = Base64.getDecoder();
+    private volatile boolean started = false;
+    private volatile boolean isInit = false;
+
+    AbstractWatcher(final List<String> kvPaths,
+                    final BlockedQueriesConsulClient consulClient,
+                    final BlockingQueriesConfiguration blockingQueriesConfiguration,
+                    final PropertiesChangeHandler propertiesChangeHandler) {
+        this.kvPaths = kvPaths;
+        this.consulClient = consulClient;
+        this.blockingQueriesConfiguration = blockingQueriesConfiguration;
+        this.propertiesChangeHandler = propertiesChangeHandler;
+    }
+
+    @Override
+    public void start() {
+        if (started) {
+            throw new IllegalStateException("Watcher is already started");
+        }
+
+        try {
+            LOG.debug("Starting KVs watcher");
+            started = true;
+            kvPaths.parallelStream()
+                .forEach(this::watchKvPath);
+        } catch (final Exception e) {
+            LOG.error("Error watching configurations: {}", e.getMessage(), e);
+            stop();
+        }
+    }
+
+    @Override
+    public boolean isWatching() {
+        return started && isInit;
+    }
+
+    @Override
+    public void stop() {
+        if (!started) {
+            LOG.warn("You tried to stop an unstarted Watcher");
+            return;
+        }
+
+        LOG.debug("Stopping KVs watchers");
+        listeners.forEach((key, value) -> {
+            try {
+                LOG.debug("Stopping watch for kvPath={}", key);
+                value.dispose();
+            } catch (final Exception e) {
+                LOG.error("Error stopping configurations watcher for kvPath={}", key, e);
+            }
+        });
+        listeners.clear();
+        kvHolder.clear();
+        started = false;
+        isInit = false;
+    }
+
+    private void watchKvPath(final String kvPath) {
+        if (!started) {
+            LOG.warn("Watcher is not started");
+            return;
+        }
+        // delaying to avoid flood caused by multiple consecutive calls
+        final var disposable = Mono.delay(blockingQueriesConfiguration.getDelayDuration())
+            .then(watchValue(kvPath))
+            .subscribe(next -> onNext(kvPath, next), throwable -> onError(kvPath, throwable));
+
+        listeners.put(kvPath, disposable);
+    }
+
+    protected abstract Mono<V> watchValue(String kvPath);
+
+    private void onNext(final String kvPath, final V next) {
+        final var previous = kvHolder.put(kvPath, next);
+
+        if (previous == null) {
+            handleInit(kvPath);
+        } else if (areEqual(previous, next)) {
+            handleNoChange(kvPath);
+        } else {
+            handleChange(kvPath, next, previous);
+        }
+
+        watchKvPath(kvPath);
+    }
+
+    protected abstract boolean areEqual(V previous, V next);
+
+    protected abstract Map<String, Object> readValue(V keyValue);
+
+    private void onError(final String kvPath, final Throwable throwable) {
+        if (throwable instanceof final HttpClientResponseException e && e.getStatus() == HttpStatus.NOT_FOUND) {
+            LOG.trace("No KV found with kvPath={}", kvPath);
+            listeners.remove(kvPath);
+        } else if (throwable instanceof ReadTimeoutException) {
+            LOG.warn("Timeout for kvPath={}", kvPath);
+            watchKvPath(kvPath);
+        } else {
+            LOG.error("Watching kvPath={} failed", kvPath, throwable);
+            listeners.remove(kvPath);
+        }
+    }
+
+    private void handleInit(final String kvPath) {
+        LOG.debug("Init watcher for kvPath={}", kvPath);
+        this.isInit = true;
+    }
+
+    private void handleNoChange(final String kvPath) {
+        LOG.debug("Nothing changed for kvPath={}", kvPath);
+    }
+
+    private void handleChange(final String kvPath, final V next, final V previous) {
+        LOG.debug("Changes detected for kvPath={}", kvPath);
+        final var previousValue = readValue(previous);
+        final var nextValue = readValue(next);
+
+        propertiesChangeHandler.handleChanges(kvPath, previousValue, nextValue);
+    }
+
+    protected final byte[] decodeValue(final KeyValue keyValue) {
+        return base64Decoder.decode(keyValue.getValue());
+    }
+
+}

--- a/discovery-client/src/main/java/io/micronaut/discovery/consul/watch/ConfigurationsWatcher.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/consul/watch/ConfigurationsWatcher.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.discovery.consul.watch;
+
+import static io.micronaut.discovery.config.ConfigDiscoveryConfiguration.Format;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.micronaut.context.env.PropertySourceReader;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.discovery.consul.client.v1.KeyValue;
+import io.micronaut.discovery.consul.client.v1.blockingqueries.BlockingQueriesConfiguration;
+import io.micronaut.discovery.consul.client.v1.blockingqueries.BlockedQueriesConsulClient;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * Watcher handling {@link Format#JSON}, {@link Format#PROPERTIES} and {@link Format#YAML} configurations.
+ *
+ * @author LE GALL Benoît
+ * @since 4.6.0
+ */
+final class ConfigurationsWatcher extends AbstractWatcher<KeyValue> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ConfigurationsWatcher.class);
+
+    private final PropertySourceReader propertySourceReader;
+
+    /**
+     * Default constructor.
+     */
+    ConfigurationsWatcher(final List<String> kvPaths,
+                                 final BlockedQueriesConsulClient consulClient,
+                                 final BlockingQueriesConfiguration blockingQueriesConfiguration,
+                                 final PropertiesChangeHandler propertiesChangeHandler,
+                                 final PropertySourceReader propertySourceReader) {
+        super(kvPaths, consulClient, blockingQueriesConfiguration, propertiesChangeHandler);
+        this.propertySourceReader = propertySourceReader;
+    }
+
+    @Override
+    protected Mono<KeyValue> watchValue(final String kvPath) {
+        final var modifiedIndex = Optional.ofNullable(kvHolder.get(kvPath))
+                .map(KeyValue::getModifyIndex)
+                .orElse(NO_INDEX);
+        LOG.debug("Watching kvPath={} with index={}", kvPath, modifiedIndex);
+        return consulClient.watchValues(kvPath, false, modifiedIndex)
+                .flatMapMany(Flux::fromIterable)
+                .filter(kv -> kvPath.equals(kv.getKey()))
+                .singleOrEmpty();
+    }
+
+    @Override
+    protected boolean areEqual(final KeyValue previous, final KeyValue next) {
+        return KvUtils.areEqual(previous, next);
+    }
+
+    @Override
+    protected Map<String, Object> readValue(final KeyValue keyValue) {
+        if (keyValue == null || StringUtils.isEmpty(keyValue.getValue())) {
+            return Collections.emptyMap();
+        }
+
+        return propertySourceReader.read(keyValue.getKey(), decodeValue(keyValue));
+    }
+
+}

--- a/discovery-client/src/main/java/io/micronaut/discovery/consul/watch/KvUtils.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/consul/watch/KvUtils.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.discovery.consul.watch;
+
+import java.util.Comparator;
+import java.util.List;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.discovery.consul.client.v1.KeyValue;
+
+/**
+ * Utils class to compare {@link KeyValue}.
+ *
+ * @author LE GALL Benoît
+ * @since 4.6.0
+ */
+@Internal
+final class KvUtils {
+
+    /**
+     * Private constructor.
+     */
+    private KvUtils() {
+    }
+
+    /**
+     * Compare 2 {@link KeyValue} by key and value.
+     *
+     * @param left  1st {@link KeyValue} to compare
+     * @param right 2d {@link KeyValue} to compare
+     * @return {@code true} if they are equals
+     */
+    static boolean areEqual(final KeyValue left, final KeyValue right) {
+        if (left == null && right == null) {
+            return true;
+        }
+
+        if (left == null || right == null) {
+            return false;
+        }
+
+        return left.getKey().equals(right.getKey()) && left.getValue().equals(right.getValue());
+    }
+
+    /**
+     * Compare 2 list of {@link KeyValue}.
+     *
+     * @param left  1st list of {@link KeyValue} to compare
+     * @param right 2d list of {@link KeyValue} to compare
+     * @return {@code true} if the list are equals
+     * @see #areEqual(KeyValue, KeyValue)
+     */
+    static boolean areEqual(final List<KeyValue> left, final List<KeyValue> right) {
+        if (left == null && right == null) {
+            return true;
+        }
+
+        if (left == null || right == null) {
+            return false;
+        }
+
+        if (left.size() != right.size()) {
+            return false;
+        }
+
+        left.sort(Comparator.comparing(KeyValue::getKey));
+        right.sort(Comparator.comparing(KeyValue::getKey));
+
+        for (int i = 0; i < left.size(); i++) {
+            final var leftKV = left.get(i);
+            final var rightKV = right.get(i);
+            if (!areEqual(rightKV, leftKV)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/discovery-client/src/main/java/io/micronaut/discovery/consul/watch/NativeWatcher.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/consul/watch/NativeWatcher.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.discovery.consul.watch;
+
+import static io.micronaut.discovery.config.ConfigDiscoveryConfiguration.Format;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.micronaut.core.util.CollectionUtils;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.discovery.consul.client.v1.KeyValue;
+import io.micronaut.discovery.consul.client.v1.blockingqueries.BlockingQueriesConfiguration;
+import io.micronaut.discovery.consul.client.v1.blockingqueries.BlockedQueriesConsulClient;
+import reactor.core.publisher.Mono;
+
+/**
+ * Watcher handling {@link Format#NATIVE} configurations.
+ *
+ * @author LE GALL Benoît
+ * @since 4.6.0
+ */
+final class NativeWatcher extends AbstractWatcher<List<KeyValue>> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(NativeWatcher.class);
+
+    private final Map<String, String> keysMap = new HashMap<>();
+
+    /**
+     * Default constructor.
+     */
+    NativeWatcher(final List<String> kvPaths,
+                         final BlockedQueriesConsulClient consulClient,
+                         final BlockingQueriesConfiguration blockingQueriesConfiguration,
+                         final PropertiesChangeHandler propertiesChangeHandler) {
+        super(kvPaths, consulClient, blockingQueriesConfiguration, propertiesChangeHandler);
+    }
+
+    @Override
+    protected Mono<List<KeyValue>> watchValue(final String kvPath) {
+        final var modifiedIndex = Optional.ofNullable(kvHolder.get(kvPath))
+                .stream()
+                .flatMap(List::stream)
+                .map(KeyValue::getModifyIndex)
+                .max(Integer::compareTo)
+                .orElse(NO_INDEX);
+        LOG.debug("Watching kvPath={} with index={}", kvPath, modifiedIndex);
+        return consulClient.watchValues(kvPath, true, modifiedIndex);
+    }
+
+    @Override
+    protected boolean areEqual(final List<KeyValue> previous, final List<KeyValue> next) {
+        return KvUtils.areEqual(previous, next);
+    }
+
+    @Override
+    protected Map<String, Object> readValue(final List<KeyValue> keyValues) {
+        if (keyValues == null) {
+            return Collections.emptyMap();
+        }
+
+        return keyValues.stream()
+                .filter(Objects::nonNull)
+                .filter(kv -> StringUtils.isNotEmpty(kv.getValue()))
+                .collect(Collectors.toMap(this::pathToPropertyKey, keyValue -> new String(decodeValue(keyValue))));
+    }
+
+    private String pathToPropertyKey(final KeyValue kv) {
+        return keysMap.computeIfAbsent(kv.getKey(), key -> CollectionUtils.last(List.of(key.split("/"))));
+    }
+
+}

--- a/discovery-client/src/main/java/io/micronaut/discovery/consul/watch/PropertiesChangeHandler.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/consul/watch/PropertiesChangeHandler.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.discovery.consul.watch;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+
+import jakarta.inject.Singleton;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.micronaut.context.env.Environment;
+import io.micronaut.context.env.PropertySource;
+import io.micronaut.context.event.ApplicationEventPublisher;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.util.CollectionUtils;
+import io.micronaut.discovery.consul.client.v1.ConsulClient;
+import io.micronaut.runtime.context.scope.refresh.RefreshEvent;
+
+/**
+ * Handle properties' configuration changes to be notified into the Micronaut context.
+ *
+ * @author LE GALL Benoît
+ * @since 4.6.0
+ */
+@Internal
+@Singleton
+public class PropertiesChangeHandler {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PropertiesChangeHandler.class);
+
+    private final Environment environment;
+    private final ApplicationEventPublisher<RefreshEvent> eventPublisher;
+
+    private final Map<String, String> propertySourceNames = new ConcurrentHashMap<>();
+
+    PropertiesChangeHandler(final Environment environment,
+                            final ApplicationEventPublisher<RefreshEvent> eventPublisher) {
+        this.environment = environment;
+        this.eventPublisher = eventPublisher;
+    }
+
+    /**
+     * Update Micronaut context with properties changes, then notify them.
+     *
+     * @param kvPath   KV path corresponding to the PropertySource updated
+     * @param previous Previous values of the PropertySource
+     * @param next     New values of the PropertySource
+     */
+    void handleChanges(final String kvPath,
+                       final Map<String, Object> previous,
+                       final Map<String, Object> next) {
+        try {
+            final var copyNext = new LinkedHashMap<>(next);
+            final var differences = new HashMap<String, Object>();
+
+            previous.forEach((key, previousValue) -> {
+                if (next.containsKey(key)) {
+                    final var nextValue = copyNext.remove(key);
+                    if (!Objects.deepEquals(previousValue, nextValue)) {
+                        // updated properties
+                        differences.put(key, previousValue);
+                    }
+                } else {
+                    // deleted properties
+                    differences.put(key, previousValue);
+                }
+            });
+
+            // remaining = added properties -> consider previous values as null
+            copyNext.keySet().forEach(key -> differences.put(key, null));
+
+            if (differences.isEmpty()) {
+                LOG.debug("No properties differences found for update of kvPath={}", kvPath);
+            } else {
+                updatePropertySources(kvPath, next);
+
+                publishDifferences(differences);
+            }
+        } catch (final Exception e) {
+            LOG.error("Unable to apply configuration changes", e);
+        }
+    }
+
+    private void updatePropertySources(final String kvPath, final Map<String, Object> newValues) {
+        final var propertySourceName = toPropertySourceName(kvPath);
+        LOG.debug("Updating context with new configurations for {}", propertySourceName);
+
+        final var updatedPropertySources = new ArrayList<PropertySource>();
+        for (final var propertySource : environment.getPropertySources()) {
+            if (propertySource.getName().equals(propertySourceName)) {
+                // creating a new PropertySource with new values but keeping the order
+                updatedPropertySources.add(PropertySource.of(propertySourceName, newValues, propertySource.getOrder()));
+            } else {
+                updatedPropertySources.add(propertySource);
+            }
+        }
+
+        updatedPropertySources.stream()
+            // /!\ re-setting all the propertySources sorted by Order, to keep precedence
+            .sorted(Comparator.comparing(PropertySource::getOrder))
+            .forEach(environment::addPropertySource);
+    }
+
+    private String toPropertySourceName(final String kvPath) {
+        return propertySourceNames.computeIfAbsent(kvPath, PropertiesChangeHandler::resolvePropertySourceName);
+    }
+
+    private static String resolvePropertySourceName(final String kvPath) {
+        final var propertySourceName = CollectionUtils.last(List.of(kvPath.split("/")));
+        final var tokens = propertySourceName.split(",");
+        if (tokens.length == 1) {
+            return ConsulClient.SERVICE_ID + '-' + propertySourceName;
+        }
+
+        final var name = tokens[0];
+        final var envName = tokens[1];
+
+        return ConsulClient.SERVICE_ID + '-' + name + '[' + envName + ']';
+    }
+
+    private void publishDifferences(final Map<String, Object> changes) {
+        if (changes.isEmpty()) {
+            return;
+        }
+
+        LOG.debug("Configuration has been updated, publishing RefreshEvent.");
+        eventPublisher.publishEvent(new RefreshEvent(changes));
+    }
+}

--- a/discovery-client/src/main/java/io/micronaut/discovery/consul/watch/WatchConfiguration.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/consul/watch/WatchConfiguration.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.discovery.consul.watch;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.core.util.Toggleable;
+import io.micronaut.discovery.consul.ConsulConfiguration;
+
+/**
+ * Configuration for Consul {@link Watcher}.
+ *
+ * @author LE GALL Benoît
+ * @since 4.6.0
+ */
+@ConfigurationProperties(WatchConfiguration.PREFIX)
+public class WatchConfiguration implements Toggleable {
+
+    /**
+     * The prefix to use for Consul's watcher settings.
+     */
+    public static final String PREFIX = ConsulConfiguration.PREFIX + ".watch";
+
+    /**
+     * The default enable value.
+     */
+    public static final boolean DEFAULT_ENABLED = false;
+
+    private boolean enabled = DEFAULT_ENABLED;
+
+    @Override
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * Sets whether Configuration watching is enabled. Default value ({@value #DEFAULT_ENABLED}).
+     *
+     * @param enabled True if it is enabled
+     */
+    public void setEnabled(final boolean enabled) {
+        this.enabled = enabled;
+    }
+}

--- a/discovery-client/src/main/java/io/micronaut/discovery/consul/watch/WatchFactory.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/consul/watch/WatchFactory.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.discovery.consul.watch;
+
+import static io.micronaut.context.env.Environment.DEFAULT_NAME;
+import static io.micronaut.discovery.config.ConfigDiscoveryConfiguration.DEFAULT_PATH;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.inject.Singleton;
+
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.env.Environment;
+import io.micronaut.context.env.PropertiesPropertySourceLoader;
+import io.micronaut.context.env.PropertySourceLoader;
+import io.micronaut.context.env.yaml.YamlPropertySourceLoader;
+import io.micronaut.context.exceptions.ConfigurationException;
+import io.micronaut.discovery.consul.ConsulConfiguration;
+import io.micronaut.discovery.consul.client.v1.blockingqueries.BlockingQueriesConfiguration;
+import io.micronaut.discovery.consul.client.v1.blockingqueries.BlockedQueriesConsulClient;
+import io.micronaut.jackson.core.env.JsonPropertySourceLoader;
+
+/**
+ * Create needed Consul {@link Watcher} based on configuration.
+ *
+ * @author LE GALL Benoît
+ * @since 4.6.0
+ */
+@Factory
+public final class WatchFactory {
+
+    private static final String CONSUL_PATH_SEPARATOR = "/";
+
+    private final Environment environment;
+    private final BlockedQueriesConsulClient consulClient;
+    private final BlockingQueriesConfiguration blockingQueriesConfiguration;
+    private final PropertiesChangeHandler propertiesChangeHandler;
+
+    public WatchFactory(final Environment environment,
+                        final BlockedQueriesConsulClient consulClient,
+                        final BlockingQueriesConfiguration blockingQueriesConfiguration,
+                        final PropertiesChangeHandler propertiesChangeHandler) {
+        this.environment = environment;
+        this.consulClient = consulClient;
+        this.blockingQueriesConfiguration = blockingQueriesConfiguration;
+        this.propertiesChangeHandler = propertiesChangeHandler;
+    }
+
+    @Singleton
+    Watcher createWatcher(final ConsulConfiguration consulConfiguration) {
+        final var kvPaths = computeKvPaths(consulConfiguration);
+
+        final var format = consulConfiguration.getConfiguration().getFormat();
+
+        return switch (format) {
+            case NATIVE -> watchNative(kvPaths);
+            case JSON -> watchConfigurations(kvPaths, new JsonPropertySourceLoader());
+            case YAML -> watchConfigurations(kvPaths, new YamlPropertySourceLoader());
+            case PROPERTIES -> watchConfigurations(kvPaths, new PropertiesPropertySourceLoader());
+            default ->
+                throw new ConfigurationException("Unhandled configuration format: " + format);
+        };
+    }
+
+    List<String> computeKvPaths(final ConsulConfiguration consulConfiguration) {
+        final var applicationName = consulConfiguration.getServiceId().orElseThrow();
+        final var configurationPath = getConfigurationPath(consulConfiguration);
+
+        final var kvPaths = new ArrayList<String>();
+        // Configuration shared by all applications
+        final var commonConfigPath = configurationPath + DEFAULT_NAME;
+        kvPaths.add(commonConfigPath);
+
+        // Application-specific configuration
+        final var applicationSpecificPath = configurationPath + applicationName;
+        kvPaths.add(applicationSpecificPath);
+
+        for (final var activeName : environment.getActiveNames()) {
+            // Configuration shared by all applications by active environments
+            kvPaths.add(toProfiledPath(commonConfigPath, activeName));
+            // Application-specific configuration by active environments
+            kvPaths.add(toProfiledPath(applicationSpecificPath, activeName));
+        }
+
+        return kvPaths;
+    }
+
+    private static String getConfigurationPath(final ConsulConfiguration consulConfiguration) {
+        return consulConfiguration.getConfiguration().getPath()
+            .map(path -> {
+                if (!path.endsWith(CONSUL_PATH_SEPARATOR)) {
+                    path += CONSUL_PATH_SEPARATOR;
+                }
+
+                return path;
+            })
+            .orElse(DEFAULT_PATH);
+    }
+
+    private static String toProfiledPath(final String resource, final String activeName) {
+        return resource + "," + activeName;
+    }
+
+    private Watcher watchNative(final List<String> keyPaths) {
+        // adding '/' at the end of the kvPath to distinct 'kvPath/' from 'kvPath,profile/'
+        final var kvPaths = keyPaths.stream().map(path -> path + CONSUL_PATH_SEPARATOR).toList();
+        return new NativeWatcher(kvPaths, consulClient, blockingQueriesConfiguration, propertiesChangeHandler);
+    }
+
+    private Watcher watchConfigurations(final List<String> kvPaths,
+                                        final PropertySourceLoader propertySourceLoader) {
+        return new ConfigurationsWatcher(kvPaths, consulClient, blockingQueriesConfiguration, propertiesChangeHandler, propertySourceLoader);
+    }
+
+}

--- a/discovery-client/src/main/java/io/micronaut/discovery/consul/watch/WatchTrigger.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/consul/watch/WatchTrigger.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.discovery.consul.watch;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.micronaut.context.annotation.Prototype;
+import io.micronaut.context.event.ShutdownEvent;
+import io.micronaut.context.event.StartupEvent;
+import io.micronaut.runtime.event.annotation.EventListener;
+
+/**
+ * Start and stop Consul {@link Watcher} on {@link StartupEvent} & {@link ShutdownEvent}.
+ *
+ * @author LE GALL Benoît
+ * @since 4.6.0
+ */
+@Prototype
+final class WatchTrigger {
+
+    private static final Logger LOG = LoggerFactory.getLogger(WatchTrigger.class);
+
+    @EventListener
+    void onStart(final StartupEvent event) {
+        LOG.info("Starting Consul watcher");
+        event.getSource().getBean(Watcher.class).start();
+    }
+
+    @EventListener
+    void onShutdown(final ShutdownEvent event) {
+        LOG.info("Shutting down Consul watcher");
+        event.getSource().getBean(Watcher.class).stop();
+    }
+}

--- a/discovery-client/src/main/java/io/micronaut/discovery/consul/watch/Watcher.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/consul/watch/Watcher.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.discovery.consul.watch;
+
+/**
+ * @author LE GALL Benoît
+ * @since 4.6.0
+ */
+public interface Watcher {
+
+    /**
+     * Start the watching.
+     */
+    void start();
+
+    /**
+     * @return {@code true} when the watcher is watching KVs
+     */
+    boolean isWatching();
+
+    /**
+     * Stop the watching.
+     */
+    void stop();
+
+}

--- a/discovery-client/src/main/java/io/micronaut/discovery/consul/watch/package-info.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/consul/watch/package-info.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * This package contains a Consul Watcher that will update the Context when application properties are changed in a Consul KV.
+ *
+ * @author LE GALL Benoît
+ * @since 4.6.0
+ */
+@Configuration
+@RequiresConsul
+@Requires(property = WatchConfiguration.PREFIX + ".enabled", value = StringUtils.TRUE, defaultValue = StringUtils.FALSE)
+package io.micronaut.discovery.consul.watch;
+
+import io.micronaut.context.annotation.Configuration;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.discovery.consul.condition.RequiresConsul;

--- a/discovery-client/src/test/groovy/io/micronaut/discovery/consul/MockConsulServer.groovy
+++ b/discovery-client/src/test/groovy/io/micronaut/discovery/consul/MockConsulServer.groovy
@@ -15,26 +15,12 @@
  */
 package io.micronaut.discovery.consul
 
-
 import io.micronaut.context.annotation.Requires
 import io.micronaut.core.annotation.Nullable
 import io.micronaut.core.async.annotation.SingleResult
 import io.micronaut.core.async.publisher.Publishers
 import io.micronaut.core.util.StringUtils
-import io.micronaut.discovery.consul.client.v1.CatalogEntry
-import io.micronaut.discovery.consul.client.v1.ConsulCatalogEntry
-import io.micronaut.discovery.consul.client.v1.ConsulCheck
-import io.micronaut.discovery.consul.client.v1.ConsulCheckStatus
-import io.micronaut.discovery.consul.client.v1.ConsulNewServiceEntry
-import io.micronaut.discovery.consul.client.v1.ConsulOperations
-import io.micronaut.discovery.consul.client.v1.ConsulServiceEntry
-import io.micronaut.discovery.consul.client.v1.ConsulHealthEntry
-import io.micronaut.discovery.consul.client.v1.HealthEntry
-import io.micronaut.discovery.consul.client.v1.KeyValue
-import io.micronaut.discovery.consul.client.v1.LocalAgentConfiguration
-import io.micronaut.discovery.consul.client.v1.MemberEntry
-import io.micronaut.discovery.consul.client.v1.NewServiceEntry
-import io.micronaut.discovery.consul.client.v1.ServiceEntry
+import io.micronaut.discovery.consul.client.v1.*
 import io.micronaut.http.HttpStatus
 import io.micronaut.http.annotation.Body
 import io.micronaut.http.annotation.Controller
@@ -43,6 +29,7 @@ import io.micronaut.http.annotation.QueryValue
 import io.micronaut.runtime.server.EmbeddedServer
 import jakarta.validation.constraints.NotNull
 import org.reactivestreams.Publisher
+import org.testcontainers.shaded.org.apache.commons.lang3.RandomUtils
 import reactor.core.publisher.Flux
 
 import java.util.concurrent.ConcurrentHashMap
@@ -100,7 +87,7 @@ class MockConsulServer implements ConsulOperations {
                 folder = key.substring(0, i)
             }
             List<KeyValue> list = keyvalues.computeIfAbsent(folder, { String k -> []})
-            list.add(new KeyValue(key, Base64.getEncoder().encodeToString(value.bytes)))
+            list.add(new KeyValue(RandomUtils.nextInt(), key, Base64.getEncoder().encodeToString(value.bytes)))
         }
         return Flux.just(true)
     }
@@ -133,7 +120,7 @@ class MockConsulServer implements ConsulOperations {
     @SingleResult
     Publisher<List<KeyValue>> readValues(String key,
                                         @Nullable @QueryValue("dc") String datacenter,
-                                        @Nullable Boolean raw, @Nullable String seperator) {
+                                        @Nullable Boolean raw, @Nullable String separator) {
         return readValues(key)
     }
 

--- a/discovery-client/src/test/groovy/io/micronaut/discovery/consul/client/v1/blockingqueries/BlockedQueryClientFilterSpec.groovy
+++ b/discovery-client/src/test/groovy/io/micronaut/discovery/consul/client/v1/blockingqueries/BlockedQueryClientFilterSpec.groovy
@@ -1,0 +1,43 @@
+package io.micronaut.discovery.consul.client.v1.blockingqueries
+
+
+import io.micronaut.http.MutableHttpParameters
+import io.micronaut.http.MutableHttpRequest
+import spock.lang.Specification
+
+import static io.micronaut.discovery.consul.client.v1.blockingqueries.BlockedQueryClientFilter.PARAMETER_INDEX
+import static io.micronaut.discovery.consul.client.v1.blockingqueries.BlockedQueryClientFilter.PARAMETER_WAIT
+
+class BlockedQueryClientFilterSpec extends Specification {
+
+    BlockingQueriesConfiguration watchConfiguration = Mock()
+    MutableHttpRequest<?> request = Mock()
+    MutableHttpParameters parameters = Mock()
+
+    BlockedQueryClientFilter blockedQueryClientFilter = new BlockedQueryClientFilter(watchConfiguration)
+
+    void "test that index parameter is not added when index is not present"() {
+        given:
+        1 * request.getParameters() >> parameters
+        1 * parameters.contains(PARAMETER_INDEX) >> false
+
+        when:
+        blockedQueryClientFilter.filterRequest(request)
+
+        then:
+        0 * parameters.add(_, _)
+    }
+
+    void "test that index parameter is added when index is present"() {
+        given:
+        1 * request.getParameters() >> parameters
+        1 * parameters.contains(PARAMETER_INDEX) >> true
+        1 * watchConfiguration.getMaxWaitDuration() >> "666s"
+
+        when:
+        blockedQueryClientFilter.filterRequest(request)
+
+        then:
+        1 * parameters.add(PARAMETER_WAIT, "666s")
+    }
+}

--- a/discovery-client/src/test/groovy/io/micronaut/discovery/consul/watch/KvUtilsSpec.groovy
+++ b/discovery-client/src/test/groovy/io/micronaut/discovery/consul/watch/KvUtilsSpec.groovy
@@ -1,0 +1,54 @@
+package io.micronaut.discovery.consul.watch
+
+
+import io.micronaut.discovery.consul.client.v1.KeyValue
+import spock.lang.Specification
+
+class KvUtilsSpec extends Specification {
+
+    void "test comparison between 2 KeyValues"(KeyValue left, KeyValue right, boolean expected) {
+        when:
+        var actual = KvUtils.areEqual(left as KeyValue, right as KeyValue)
+
+        then:
+        actual == expected
+
+        where:
+        left                            | right                             | expected
+        null                            | null                              | true
+        new KeyValue(0, "key", "value") | null                              | false
+        null                            | new KeyValue(0, "key", "value")   | false
+        new KeyValue(0, "key", "value") | new KeyValue(0, "key_2", "value") | false
+        new KeyValue(0, "key", "value") | new KeyValue(0, "key", "value_2") | false
+        new KeyValue(0, "key", "value") | new KeyValue(0, "key", "value")   | true
+    }
+
+    void "test comparison between 2 lists of KeyValues"(final List<KeyValue> left, final List<KeyValue> right, final boolean expected) {
+        when:
+        var actual = KvUtils.areEqual(left, right)
+
+        then:
+        actual == expected
+
+        where:
+        left                                                                           | right                                                                          | expected
+        null                                                                           | null                                                                           | true
+        createList(new KeyValue(0, "key", "value"))                                    | null                                                                           | false
+        null                                                                           | createList(new KeyValue(0, "key", "value"))                                    | false
+        createList(new KeyValue(0, "key", "value"))                                    | createList(new KeyValue(0, "key_2", "value"))                                  | false
+        createList(new KeyValue(0, "key", "value"), new KeyValue(0, "key_2", "value")) | createList(new KeyValue(0, "key_2", "value"))                                  | false
+        createList(new KeyValue(0, "key", "value"))                                    | createList(new KeyValue(0, "key", "value"), new KeyValue(0, "key_2", "value")) | false
+        createList(new KeyValue(0, "key", "value"))                                    | createList(new KeyValue(0, "key", "value_2"))                                  | false
+        createList(new KeyValue(0, "key", "value"))                                    | createList(new KeyValue(0, "key", "value"))                                    | true
+        createList(new KeyValue(0, "key", "value"), new KeyValue(0, "key_2", "value")) | createList(new KeyValue(0, "key_2", "value"), new KeyValue(0, "key", "value")) | true
+    }
+
+    private static List<KeyValue> createList(KeyValue... keyValues) {
+        var list = new ArrayList<KeyValue>()
+        for (final def kv in keyValues) {
+            list.add(kv)
+        }
+
+        return list
+    }
+}

--- a/discovery-client/src/test/groovy/io/micronaut/discovery/consul/watch/PropertiesChangeHandlerSpec.groovy
+++ b/discovery-client/src/test/groovy/io/micronaut/discovery/consul/watch/PropertiesChangeHandlerSpec.groovy
@@ -1,0 +1,109 @@
+package io.micronaut.discovery.consul.watch
+
+import io.micronaut.context.env.Environment
+import io.micronaut.context.env.PropertySource
+import io.micronaut.context.event.ApplicationEventPublisher
+import io.micronaut.runtime.context.scope.refresh.RefreshEvent
+import spock.lang.Specification
+
+class PropertiesChangeHandlerSpec extends Specification {
+
+    Environment environment = Mock()
+    ApplicationEventPublisher<RefreshEvent> eventPublisher = Mock()
+
+    PropertiesChangeHandler propertiesChangeHandler = new PropertiesChangeHandler(environment, eventPublisher)
+
+    void "test that Context is updated and RefreshEvent is published"() {
+        given:
+        def capturedProperties = new ArrayList<PropertySource>()
+        final Map<String, Object> previous = new HashMap<>()
+        previous.put("key_1", "value_1")
+        previous.put("key_2", null)
+        previous.put("key_3", "null")
+        previous.put("key_4", null)
+        previous.put("key_to_delete", "foo")
+
+        final Map<String, Object> next = new HashMap<>()
+        next.put("key_1", "value_2")
+        next.put("key_2", "null")
+        next.put("key_3", null)
+        next.put("key_4", null)
+        next.put("key_added", "bar")
+
+        final var propertySources = new ArrayList<PropertySource>()
+        propertySources.add(PropertySource.of("consul-consul-watcher[test]", previous, 99))
+        propertySources.add(PropertySource.of("consul-application", Map.of("key_a", "value_a"), 66))
+        1 * environment.getPropertySources() >> propertySources
+
+        when:
+        propertiesChangeHandler.handleChanges("config/consul-watcher,test", previous, next)
+
+        then:
+        2 * environment.addPropertySource(_ as PropertySource) >> { arguments ->
+            capturedProperties.add(arguments[0])
+            return environment
+        }
+        final var propertySource = capturedProperties
+                .stream()
+                .filter(ps -> ps.getName() == "consul-consul-watcher[test]")
+                .findFirst()
+        propertySource.isPresent()
+        with(propertySource.get()) { ps ->
+            ps.get("key_1") == "value_2"
+            ps.get("key_2") == "null"
+            ps.get("key_3") == null
+            ps.get("key_4") == null
+                }
+
+        1 * eventPublisher.publishEvent({
+            it instanceof RefreshEvent
+            def refreshEvent = it as RefreshEvent
+            with(refreshEvent.getSource()) { source ->
+                source.size() == 5
+            // updated keys, with previous values
+                source.get("key_1") == "value_1"
+                source.get("key_2") == null
+                source.get("key_3") == "null"
+            // deleted key, with previous value
+                source.get("key_to_delete") == "foo"
+            // added key, with null value ?
+                source.get("key_added") == null
+            }
+        })
+    }
+
+    void "test that nothing is done when no differences found"() {
+        given:
+        final Map<String, Object> previous = Map.of("key_1", "value_1")
+        final Map<String, Object> next = Map.of("key_1", "value_1")
+
+        when:
+        propertiesChangeHandler.handleChanges("config/consul-watcher", previous, next)
+
+        then:
+        0 * environment._
+        0 * eventPublisher._
+    }
+
+    void "test that keep going when type classes are different but numbers"() {
+        given:
+        final Map<String, Object> previous = Map.of("key_int", 1)
+        final Map<String, Object> next = Map.of("key_int", 1.0)
+
+        final var propertySources = new ArrayList<PropertySource>()
+        propertySources.add(PropertySource.of("consul-application", Map.of("key_int", 1), 66))
+        1 * environment.getPropertySources() >> propertySources
+
+        when:
+        propertiesChangeHandler.handleChanges("config/application", previous, next)
+
+        then:
+        1 * environment.addPropertySource({ it.get("key_int").toString() == "1.0" })
+        1 * eventPublisher.publishEvent({
+            it instanceof RefreshEvent
+            def refreshEvent = it as RefreshEvent
+            refreshEvent.getSource().get("key_int").toString() == "1"
+        })
+    }
+
+}

--- a/discovery-client/src/test/groovy/io/micronaut/discovery/consul/watch/WatchConfigurationSpec.groovy
+++ b/discovery-client/src/test/groovy/io/micronaut/discovery/consul/watch/WatchConfigurationSpec.groovy
@@ -1,0 +1,46 @@
+package io.micronaut.discovery.consul.watch
+
+import io.micronaut.core.convert.ConversionService
+import io.micronaut.core.reflect.ReflectionUtils
+import io.micronaut.discovery.consul.ConsulConfiguration
+import io.micronaut.discovery.consul.client.v1.blockingqueries.BlockingQueriesConfiguration
+import spock.lang.Specification
+
+import java.time.Duration
+
+import static io.micronaut.discovery.consul.client.v1.blockingqueries.BlockingQueriesConfiguration.DEFAULT_MAX_WAIT_DURATION_MINUTES
+
+class WatchConfigurationSpec extends Specification {
+
+    ConsulConfiguration consulConfiguration = Mock()
+    ConversionService conversionService = Mock()
+
+    BlockingQueriesConfiguration watchConfiguration = new BlockingQueriesConfiguration(consulConfiguration, conversionService)
+
+    void "test that the default read timeout is used"() {
+        given:
+        1 * conversionService.convertRequired(DEFAULT_MAX_WAIT_DURATION_MINUTES, Duration.class) >> Duration.ofMinutes(10)
+
+        when:
+        def readTimeout1 = watchConfiguration.getReadTimeout()
+        def readTimeout2 = watchConfiguration.getReadTimeout()
+
+        then:
+        readTimeout1.isPresent()
+        readTimeout1.get().toSeconds() == 637
+        readTimeout1 == readTimeout2
+    }
+
+    void "test that the read timeout is calculated when setting max wait duration"() {
+        given:
+        1 * conversionService.convertRequired("16s", Duration.class) >> Duration.ofSeconds(16)
+
+        when:
+        watchConfiguration.setMaxWaitDuration("16s");
+
+        then:
+        Optional<Duration> readTimeoutValue = ReflectionUtils.getFieldValue(BlockingQueriesConfiguration.class, "readTimeout", watchConfiguration)
+        readTimeoutValue.isPresent()
+        readTimeoutValue.get().toSeconds() == 17
+    }
+}

--- a/discovery-client/src/test/groovy/io/micronaut/discovery/consul/watch/WatchFactorySpec.groovy
+++ b/discovery-client/src/test/groovy/io/micronaut/discovery/consul/watch/WatchFactorySpec.groovy
@@ -1,0 +1,107 @@
+package io.micronaut.discovery.consul.watch
+
+import io.micronaut.context.env.Environment
+import io.micronaut.context.exceptions.ConfigurationException
+import io.micronaut.core.reflect.ReflectionUtils
+import io.micronaut.discovery.consul.ConsulConfiguration
+import io.micronaut.discovery.consul.client.v1.blockingqueries.BlockingQueriesConfiguration
+import io.micronaut.discovery.consul.client.v1.blockingqueries.BlockedQueriesConsulClient
+import spock.lang.Specification
+
+import static io.micronaut.discovery.config.ConfigDiscoveryConfiguration.Format.*
+import static io.micronaut.discovery.config.ConfigDiscoveryConfiguration.Format
+
+class WatchFactorySpec extends Specification {
+
+    Environment environment = Mock()
+    BlockedQueriesConsulClient consulClient = Mock()
+    BlockingQueriesConfiguration watchConfiguration = Mock()
+    PropertiesChangeHandler propertiesChangeHandler = Mock()
+
+    WatchFactory watchFactory = new WatchFactory(environment, consulClient, watchConfiguration, propertiesChangeHandler)
+
+    void "test that all required KV paths are watched"() {
+        given:
+        def consulConfiguration = Mock(ConsulConfiguration)
+        def discoveryConfiguration = Mock(ConsulConfiguration.ConsulConfigDiscoveryConfiguration)
+        1 * consulConfiguration.getServiceId() >> Optional.of("my_application")
+        1 * consulConfiguration.getConfiguration() >> discoveryConfiguration
+        1 * discoveryConfiguration.getPath() >> Optional.of("path/to/config")
+        1 * environment.getActiveNames() >> Set.of("cloud", "test")
+
+        when:
+        def kvPaths = watchFactory.computeKvPaths(consulConfiguration)
+
+        then:
+        kvPaths.size() == 6
+        kvPaths.contains("path/to/config/application")
+        kvPaths.contains("path/to/config/application,cloud")
+        kvPaths.contains("path/to/config/application,test")
+        kvPaths.contains("path/to/config/my_application")
+        kvPaths.contains("path/to/config/my_application,cloud")
+        kvPaths.contains("path/to/config/my_application,test")
+    }
+
+    void "test that an exception is thrown when the format is not supported"() {
+        given:
+        def consulConfiguration = Mock(ConsulConfiguration)
+        def discoveryConfiguration = Mock(ConsulConfiguration.ConsulConfigDiscoveryConfiguration)
+        1 * consulConfiguration.getServiceId() >> Optional.of("my_application")
+        2 * consulConfiguration.getConfiguration() >> discoveryConfiguration
+        1 * discoveryConfiguration.getPath() >> Optional.of("path/to/config")
+        1 * discoveryConfiguration.getFormat() >> FILE
+        1 * environment.getActiveNames() >> Set.of()
+
+        when:
+        watchFactory.createWatcher(consulConfiguration)
+
+        then:
+        thrown(ConfigurationException)
+    }
+
+    void "test than NATIVE format is supported"() {
+        given:
+        def consulConfiguration = Mock(ConsulConfiguration)
+        def discoveryConfiguration = Mock(ConsulConfiguration.ConsulConfigDiscoveryConfiguration)
+        1 * consulConfiguration.getServiceId() >> Optional.of("my_application")
+        2 * consulConfiguration.getConfiguration() >> discoveryConfiguration
+        1 * discoveryConfiguration.getPath() >> Optional.of("path/to/native")
+        1 * discoveryConfiguration.getFormat() >> NATIVE
+        1 * environment.getActiveNames() >> Set.of()
+
+        when:
+        def watcher = watchFactory.createWatcher(consulConfiguration)
+
+        then:
+        watcher instanceof NativeWatcher
+        def kvPaths = ReflectionUtils.getFieldValue(NativeWatcher.class, "kvPaths", watcher)
+        kvPaths.isPresent()
+        kvPaths.get() == List.of("path/to/native/application/", "path/to/native/my_application/")
+    }
+
+    void "test than #format format is supported"(Format format) {
+        given:
+        def consulConfiguration = Mock(ConsulConfiguration)
+        def discoveryConfiguration = Mock(ConsulConfiguration.ConsulConfigDiscoveryConfiguration)
+        1 * consulConfiguration.getServiceId() >> Optional.of("my_application")
+        2 * consulConfiguration.getConfiguration() >> discoveryConfiguration
+        1 * discoveryConfiguration.getPath() >> Optional.of("path/to/" + format.name())
+        1 * discoveryConfiguration.getFormat() >> format
+        1 * environment.getActiveNames() >> Set.of()
+
+        when:
+        def watcher = watchFactory.createWatcher(consulConfiguration)
+
+        then:
+        watcher instanceof ConfigurationsWatcher
+        def kvPaths = ReflectionUtils.getFieldValue(NativeWatcher.class, "kvPaths", watcher)
+        kvPaths.isPresent()
+        kvPaths.get() == List.of("path/to/" + format.name() + "/application", "path/to/" + format.name() + "/my_application")
+
+        where:
+        format     | _
+        JSON       | _
+        PROPERTIES | _
+        YAML       | _
+    }
+}

--- a/discovery-client/src/test/groovy/io/micronaut/discovery/consul/watch/WatchTriggerSpec.groovy
+++ b/discovery-client/src/test/groovy/io/micronaut/discovery/consul/watch/WatchTriggerSpec.groovy
@@ -1,0 +1,40 @@
+package io.micronaut.discovery.consul.watch
+
+import io.micronaut.context.BeanContext
+import io.micronaut.context.event.ShutdownEvent
+import io.micronaut.context.event.StartupEvent
+import spock.lang.Shared
+import spock.lang.Specification
+
+class WatchTriggerSpec extends Specification {
+
+    @Shared
+    WatchTrigger watcherTrigger = new WatchTrigger()
+
+    BeanContext beanContext = Mock()
+    Watcher watcher = Mock()
+
+    void "test that the Watch is started on StartupEvent"() {
+        given:
+        beanContext.getBean(Watcher) >> watcher
+
+        when:
+        watcherTrigger.onStart(new StartupEvent(beanContext))
+
+        then:
+        1 * watcher.start()
+        0 * watcher._
+    }
+
+    void "test that the Watch is stopped on ShutdownEvent"() {
+        given:
+        beanContext.getBean(Watcher) >> watcher
+
+        when:
+        watcherTrigger.onShutdown(new ShutdownEvent(beanContext))
+
+        then:
+        1 * watcher.stop()
+        0 * watcher._
+    }
+}

--- a/discovery-client/src/test/groovy/io/micronaut/discovery/consul/watch/WatcherSpec.groovy
+++ b/discovery-client/src/test/groovy/io/micronaut/discovery/consul/watch/WatcherSpec.groovy
@@ -1,0 +1,423 @@
+package io.micronaut.discovery.consul.watch
+
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.classic.spi.ThrowableProxy
+import ch.qos.logback.core.read.ListAppender
+import io.micronaut.context.env.PropertySourceReader
+import io.micronaut.context.env.yaml.YamlPropertySourceLoader
+import io.micronaut.discovery.consul.client.v1.KeyValue
+import io.micronaut.discovery.consul.client.v1.blockingqueries.BlockingQueriesConfiguration
+import io.micronaut.discovery.consul.client.v1.blockingqueries.BlockedQueriesConsulClient
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.client.exceptions.HttpClientResponseException
+import io.micronaut.http.client.exceptions.ReadTimeoutException
+import org.slf4j.LoggerFactory
+import reactor.core.publisher.Mono
+import spock.lang.Specification
+import spock.util.concurrent.AsyncConditions
+
+import java.time.Duration
+
+class WatcherSpec extends Specification {
+
+    private static Logger CLASS_LOGGER = (Logger) LoggerFactory.getLogger(AbstractWatcher.class)
+
+    BlockedQueriesConsulClient consulClient = Mock()
+    BlockingQueriesConfiguration watchConfiguration = Mock()
+    PropertiesChangeHandler propertiesChangeHandler = Mock()
+
+    PropertySourceReader propertySourceReader = new YamlPropertySourceLoader()
+    Base64.Encoder base64Encoder = Base64.getEncoder()
+
+    Watcher watcher
+    ListAppender<ILoggingEvent> listAppender
+
+    def setup() {
+        CLASS_LOGGER.setLevel(Level.INFO)
+    }
+
+    def cleanup() {
+        if (listAppender != null) {
+            CLASS_LOGGER.detachAppender(listAppender)
+            listAppender.stop()
+            listAppender = null
+        }
+
+        if (watcher != null && watcher.isWatching()) {
+            watcher.stop()
+        }
+    }
+
+    void "test that Configurations changes are published"() {
+        given:
+        def conditions = new AsyncConditions()
+
+        watcher = new ConfigurationsWatcher(List.of("path/to/yaml"), consulClient, watchConfiguration, propertiesChangeHandler, propertySourceReader)
+
+        def keyValue = new KeyValue(1234, "path/to/yaml", base64Encoder.encodeToString("foo.bar: value".getBytes()))
+        def newKeyValue = new KeyValue(4567, "path/to/yaml", base64Encoder.encodeToString("foo.bar: value_2".getBytes()))
+
+        1 * consulClient.watchValues("path/to/yaml", false, null) >> Mono.just(List.of(keyValue)) // init
+        2 * consulClient.watchValues("path/to/yaml", false, 1234) >>> [
+                Mono.delay(Duration.ofMillis(200))
+                        .thenReturn(List.of(keyValue)), // no change
+                Mono.delay(Duration.ofMillis(200))
+                        .thenReturn(List.of(newKeyValue)) // change
+        ]
+
+        watchConfiguration.getDelayDuration() >> Duration.ZERO
+
+        1 * propertiesChangeHandler.handleChanges(
+                "path/to/yaml",
+                {
+                    Map<String, Object> previous ->
+                        conditions.evaluate {
+                            verifyAll {
+                                previous.size() == 1
+                                previous.get("foo.bar") == "value"
+                            }
+                        }
+                },
+                {
+                    Map<String, Object> next ->
+                        conditions.evaluate {
+                            verifyAll {
+                                next.size() == 1
+                                next.get("foo.bar") == "value_2"
+                            }
+                        }
+                })
+
+        when:
+        watcher.start()
+
+        then:
+        conditions.await(5)
+    }
+
+    void "test that Configuration handle null KV"() {
+        given:
+        watcher = new ConfigurationsWatcher(List.of("path/to/yaml"), consulClient, watchConfiguration, propertiesChangeHandler, propertySourceReader)
+
+        when:
+        def value = watcher.readValue(null)
+
+        then:
+        value.isEmpty()
+    }
+
+    void "test that Native changes are published"() {
+        given:
+        def conditions = new AsyncConditions()
+
+        watcher = new NativeWatcher(List.of("path/to/"), consulClient, watchConfiguration, propertiesChangeHandler)
+
+        def previousKeyValue1 = new KeyValue(12, "path/to/foo.bar", base64Encoder.encodeToString("value_a".getBytes()))
+        def previousKeyValue2 = new KeyValue(34, "path/to/other.key", base64Encoder.encodeToString("value_b".getBytes()))
+        def previousKvs = new ArrayList<>(List.of(previousKeyValue1, previousKeyValue2))
+
+        def nextKeyValue1 = new KeyValue(56, "path/to/foo.bar", base64Encoder.encodeToString("value_c".getBytes()))
+        def nextKeyValue2 = new KeyValue(78, "path/to/other.key", base64Encoder.encodeToString("value_b".getBytes()))
+        def nextKvs = new ArrayList<>(List.of(nextKeyValue1, nextKeyValue2))
+
+        1 * consulClient.watchValues("path/to/", true, null) >> Mono.just(previousKvs) // init
+        2 * consulClient.watchValues("path/to/", true, 34) >>> [
+                Mono.delay(Duration.ofMillis(200))
+                        .thenReturn(previousKvs), // no change
+                Mono.delay(Duration.ofMillis(200))
+                        .thenReturn(nextKvs) // change
+        ]
+
+        _ * consulClient.watchValues("path/to/", true, 78) >> Mono.delay(Duration.ofSeconds(10))
+                .thenReturn(nextKvs) // no change
+
+        watchConfiguration.getDelayDuration() >> Duration.ZERO
+
+        1 * propertiesChangeHandler.handleChanges(
+                "path/to/",
+                { previous ->
+                    conditions.evaluate {
+                        verifyAll {
+                            previous.size() == 2
+                            previous.get("foo.bar") == "value_a"
+                            previous.get("other.key") == "value_b"
+                        }
+                    }
+                },
+                { next ->
+                    conditions.evaluate {
+                        verifyAll {
+                            next.size() == 2
+                            next.get("foo.bar") == "value_c"
+                            next.get("other.key") == "value_b"
+                        }
+                    }
+                })
+
+        when:
+        watcher.start()
+
+        then:
+        conditions.await(5)
+    }
+
+    void "test that Native handle null KV"() {
+        given:
+        watcher = new NativeWatcher(List.of("path/to/yaml"), consulClient, watchConfiguration, propertiesChangeHandler)
+
+        when:
+        def value = watcher.readValue(null)
+
+        then:
+        value.isEmpty()
+    }
+
+    void "test that global error are logged"() {
+        given:
+        listAppender = new ListAppender<ILoggingEvent>()
+        listAppender.start()
+        CLASS_LOGGER.addAppender(listAppender)
+        CLASS_LOGGER.setLevel(Level.ERROR)
+
+        watcher = new ConfigurationsWatcher(List.of("path/to/global_error"), consulClient, watchConfiguration, propertiesChangeHandler, propertySourceReader)
+
+        def keyValue = new KeyValue(0, "path/to/global_error", "")
+        def newKeyValue = new KeyValue(1, "path/to/global_error", "incorrect data")
+        1 * consulClient.watchValues("path/to/global_error", false, null) >> Mono.just(List.of(keyValue)) // init
+        1 * consulClient.watchValues("path/to/global_error", false, 0) >> Mono.just(List.of(newKeyValue)) // change
+
+        watchConfiguration.getDelayDuration() >> Duration.ZERO
+
+        when:
+        watcher.start()
+
+        then:
+        Thread.sleep(500)
+        listAppender.list.size() == 1
+        def loggingEvent = listAppender.list.get(0)
+        loggingEvent.getFormattedMessage() == "Watching kvPath=path/to/global_error failed"
+        with((ThrowableProxy) loggingEvent.getThrowableProxy()) {
+            def throwable = it.getThrowable()
+            throwable instanceof IllegalArgumentException
+            throwable.getMessage() == "Illegal base64 character 20"
+        }
+
+        0 * propertiesChangeHandler._
+    }
+
+    void "test that client NOT_FOUND errors are handled"() {
+        given:
+        listAppender = new ListAppender<ILoggingEvent>()
+        listAppender.start()
+        CLASS_LOGGER.addAppender(listAppender)
+        CLASS_LOGGER.setLevel(Level.TRACE)
+
+        watcher = new ConfigurationsWatcher(List.of("path/to/NOT_FOUND"), consulClient, watchConfiguration, propertiesChangeHandler, propertySourceReader)
+
+        def exception = Mock(HttpClientResponseException)
+        1 * exception.getStatus() >> HttpStatus.NOT_FOUND
+        1 * consulClient.watchValues("path/to/NOT_FOUND", false, null) >> Mono.error(exception)
+        watchConfiguration.getDelayDuration() >> Duration.ZERO
+
+        when:
+        watcher.start()
+
+        then:
+        def logs = listAppender.list.stream()
+                .filter(event -> Level.TRACE == event.getLevel())
+                .toList()
+        logs.size() == 1
+        def loggingEvent = logs.get(0)
+        loggingEvent.getFormattedMessage() == "No KV found with kvPath=path/to/NOT_FOUND"
+        ((ThrowableProxy) loggingEvent.getThrowableProxy()) == null
+
+        and:
+        0 * propertiesChangeHandler._
+    }
+
+    void "test that client http errors are handled"() {
+        given:
+        listAppender = new ListAppender<ILoggingEvent>()
+        listAppender.start()
+        CLASS_LOGGER.addAppender(listAppender)
+        CLASS_LOGGER.setLevel(Level.ERROR)
+
+        watcher = new ConfigurationsWatcher(List.of("path/to/http_error"), consulClient, watchConfiguration, propertiesChangeHandler, propertySourceReader)
+
+        def exception = Mock(HttpClientResponseException)
+        1 * exception.getStatus() >> HttpStatus.INTERNAL_SERVER_ERROR
+        1 * consulClient.watchValues("path/to/http_error", false, null) >> Mono.error(exception)
+        watchConfiguration.getDelayDuration() >> Duration.ZERO
+
+        when:
+        watcher.start()
+
+        then:
+        def logs = listAppender.list.stream()
+                .filter(event -> Level.ERROR == event.getLevel())
+                .toList()
+        logs.size() == 1
+        def loggingEvent = logs.get(0)
+        loggingEvent.getFormattedMessage() == "Watching kvPath=path/to/http_error failed"
+        ((ThrowableProxy) loggingEvent.getThrowableProxy()) != null
+        ((ThrowableProxy) loggingEvent.getThrowableProxy()).getThrowable() == exception
+
+        and:
+        0 * propertiesChangeHandler._
+    }
+
+    void "test that client timeout errors are handled"() {
+        given:
+        listAppender = new ListAppender<ILoggingEvent>()
+        listAppender.start()
+        CLASS_LOGGER.addAppender(listAppender)
+        CLASS_LOGGER.setLevel(Level.WARN)
+
+        watcher = new ConfigurationsWatcher(List.of("path/to/timeout"), consulClient, watchConfiguration, propertiesChangeHandler, propertySourceReader)
+
+        def exception = ReadTimeoutException.TIMEOUT_EXCEPTION
+        2 * consulClient.watchValues("path/to/timeout", false, null) >> Mono.error(exception)
+        watchConfiguration.getDelayDuration() >>> [Duration.ZERO, Duration.ofSeconds(5)]
+
+        when:
+        watcher.start()
+
+        then:
+        def logs = listAppender.list.stream()
+                .filter(event -> Level.WARN == event.getLevel())
+                .toList()
+        logs.size() == 1
+        def loggingEvent = logs.get(0)
+        loggingEvent.getFormattedMessage() == "Timeout for kvPath=path/to/timeout"
+        ((ThrowableProxy) loggingEvent.getThrowableProxy()) == null
+
+        and:
+        0 * propertiesChangeHandler._
+    }
+
+    void "test that other client errors are handled"() {
+        given:
+        listAppender = new ListAppender<ILoggingEvent>()
+        listAppender.start()
+        CLASS_LOGGER.addAppender(listAppender)
+        CLASS_LOGGER.setLevel(Level.ERROR)
+
+        watcher = new ConfigurationsWatcher(List.of("path/to/error_other"), consulClient, watchConfiguration, propertiesChangeHandler, propertySourceReader)
+
+        def exception = new RuntimeException("boom")
+        1 * consulClient.watchValues("path/to/error_other", false, null) >> Mono.error(exception)
+        watchConfiguration.getDelayDuration() >> Duration.ZERO
+
+        when:
+        watcher.start()
+
+        then:
+        def logs = listAppender.list.stream()
+                .filter(event -> Level.ERROR == event.getLevel())
+                .toList()
+        logs.size() == 1
+        def loggingEvent = logs.get(0)
+        loggingEvent.getFormattedMessage() == "Watching kvPath=path/to/error_other failed"
+        ((ThrowableProxy) loggingEvent.getThrowableProxy()) != null
+        ((ThrowableProxy) loggingEvent.getThrowableProxy()).getThrowable() == exception
+
+        and:
+        0 * propertiesChangeHandler._
+    }
+
+    void "test that an Exception is thrown when Watcher is already started"() {
+        given:
+        watcher = new ConfigurationsWatcher(List.of(), consulClient, watchConfiguration, propertiesChangeHandler, propertySourceReader)
+
+        when:
+        watcher.start()
+        watcher.start()
+
+        then:
+        def caughtException = thrown(IllegalStateException)
+        caughtException.message == "Watcher is already started"
+
+        and:
+        0 * consulClient._
+        0 * watchConfiguration._
+        0 * propertiesChangeHandler._
+    }
+
+    void "test that ERROR are logged and watcher is stopped when and exception occurs during start"() {
+        given:
+        listAppender = new ListAppender<ILoggingEvent>()
+        listAppender.start()
+        CLASS_LOGGER.addAppender(listAppender)
+
+        watcher = new ConfigurationsWatcher(List.of("path/to/yaml"), consulClient, watchConfiguration, propertiesChangeHandler, propertySourceReader)
+
+        def exception = new RuntimeException("boom")
+        1 * consulClient.watchValues("path/to/yaml", false, null) >> { throw exception }
+        watchConfiguration.getDelayDuration() >> Duration.ZERO
+
+        when:
+        watcher.start()
+
+        then:
+        def logs = listAppender.list.stream()
+                .filter(event -> Level.ERROR == event.getLevel())
+                .toList()
+        logs.size() == 1
+        def loggingEvent = logs.get(0)
+        loggingEvent.getFormattedMessage() == "Error watching configurations: boom"
+        with((ThrowableProxy) loggingEvent.getThrowableProxy()) {
+            it.getThrowable() == exception
+        }
+
+        and:
+        0 * propertiesChangeHandler._
+    }
+
+    void "test that WARN are logged when stopping a not started watcher"() {
+        given:
+        listAppender = new ListAppender<ILoggingEvent>()
+        listAppender.start()
+        CLASS_LOGGER.addAppender(listAppender)
+        CLASS_LOGGER.setLevel(Level.WARN)
+
+        watcher = new ConfigurationsWatcher(List.of(), consulClient, watchConfiguration, propertiesChangeHandler, propertySourceReader)
+
+        when:
+        watcher.stop()
+
+        then:
+        def logs = listAppender.list.stream()
+                .filter(event -> Level.WARN == event.getLevel())
+                .toList()
+        logs.size() == 1
+        def loggingEvent = logs.get(0)
+        loggingEvent.getFormattedMessage() == "You tried to stop an unstarted Watcher"
+
+        and:
+        0 * consulClient._
+        0 * watchConfiguration._
+        0 * propertiesChangeHandler._
+    }
+
+    void "test that stopping Watcher dispose all subscriptions"() {
+        given:
+        watcher = new ConfigurationsWatcher(List.of("path/to/yaml"), consulClient, watchConfiguration, propertiesChangeHandler, propertySourceReader)
+        def keyValue = new KeyValue(1234, "path/to/yaml", base64Encoder.encodeToString("foo.bar: value".getBytes()))
+
+        // fixme mock result to check the dispose call ?
+        1 * consulClient.watchValues("path/to/yaml", false, null) >> Mono.delay(Duration.ofMillis(200))
+                .thenReturn(List.of(keyValue))
+
+        watchConfiguration.getDelayDuration() >> Duration.ZERO
+
+        when:
+        watcher.start()
+        watcher.stop()
+
+        then:
+        0 * propertiesChangeHandler._
+        // fixme check that Disposable#dispose() is called
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,8 @@ micronaut-test-resources="2.7.0"
 micronaut-validation = "4.8.0"
 micronaut-logging = "1.4.0"
 
+commons-lang3 = "3.17.0"
+
 groovy = "4.0.17"
 spock = "2.3-groovy-4.0"
 awaitility = "4.2.2"
@@ -28,8 +30,11 @@ micronaut-validation = { module = "io.micronaut.validation:micronaut-validation-
 micronaut-docs-asciidoc-config-props = { module = "io.micronaut.docs:micronaut-docs-asciidoc-config-props", version.ref = "micronaut-docs" }
 awaitility = { module = "org.awaitility:awaitility", version.ref = "awaitility" }
 
+commons-lang3 = { module = "org.apache.commons:commons-lang3", version.ref = "commons-lang3" }
+
 spock = { module = 'org.spockframework:spock-core', version.ref = "spock" }
 testcontainers-junit-jupiter = { module = "org.testcontainers:junit-jupiter"}
+testcontainers-consul = { module = "org.testcontainers:consul" }
 
 junit-jupiter-engine = { module = 'org.junit.jupiter:junit-jupiter-engine' }
 junit-platform-engine = { module = "org.junit.platform:junit-platform-suite-engine" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,6 +17,7 @@ include 'discovery-client-tests'
 include 'test-suite-consul-graal'
 include 'test-suite-consul-graal-serde'
 include 'test-suite-consul-graal-jacksondatabind'
+include 'test-suite-consul-watch'
 
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 

--- a/src/main/docs/guide/serviceDiscoveryConsul.adoc
+++ b/src/main/docs/guide/serviceDiscoveryConsul.adoc
@@ -169,3 +169,50 @@ consul:
       check:
         http: true
 ----
+
+== Consul Watch
+
+The watcher calls the https://developer.hashicorp.com/consul/api-docs/kv[KV Store API] to watch all keys used for the distributed configurations,
+using https://developer.hashicorp.com/consul/api-docs/features/blocking[Blocking Queries]
+to wait for any changes made on those keys.
+If no change occurred during the `max-wait-duration`, the query will be re-executed after the `delay-duration`.
+When a change is detected in a KV used for configurations,
+the corresponding `PropertySource` will be updated and a `RefreshEvent` published.
+
+See https://docs.micronaut.io/latest/guide/index.html#refreshable[Micronaut > Refreshable Scope] for more details
+
+=== Configuration
+
+The watcher can be configured using
+
+.Consul Watch Configuration
+[configuration]
+----
+micronaut:
+  application:
+    name: hello-world
+  config-client:
+    enabled: true
+
+consul:
+  client:
+    defaultZone: "${CONSUL_HOST:localhost}:${CONSUL_PORT:8500}"
+    config:
+      format: YAML
+      path: /config
+    watch:
+      enabled: true
+    blocking-queries:
+      max-wait-duration: 10m
+      delay-duration: 50ms
+----
+
+Formats supported are
+
+- `NATIVE`
+- `JSON`
+- `PROPERTIES`
+- `YAML`
+
+Read https://docs.micronaut.io/latest/guide/index.html#distributedConfigurationConsul[Micronaut > Distributed Configuration > HashiCorp Consul Support]
+for more details.

--- a/test-suite-consul-watch/build.gradle.kts
+++ b/test-suite-consul-watch/build.gradle.kts
@@ -1,0 +1,28 @@
+plugins {
+    id("io.micronaut.build.internal.discovery-client-base")
+    id("io.micronaut.minimal.library") version "4.4.4"
+}
+
+dependencies {
+    annotationProcessor(mn.micronaut.inject.java)
+
+    implementation(projects.micronautDiscoveryClient)
+    implementation(mnTest.micronaut.test.junit5)
+    implementation(mnTest.assertj.core)
+    implementation(mnSerde.micronaut.serde.jackson)
+    implementation(libs.testcontainers.junit.jupiter)
+    implementation(libs.testcontainers.consul)
+    implementation(libs.awaitility)
+    implementation(libs.commons.lang3)
+
+    testImplementation(libs.junit.platform.engine)
+
+    testRuntimeOnly(mn.micronaut.http.client)
+    testRuntimeOnly(mn.snakeyaml)
+    testRuntimeOnly(mnLogging.logback.classic)
+}
+
+micronaut {
+    version.set(libs.versions.micronaut.platform.get())
+    testRuntime("junit5")
+}

--- a/test-suite-consul-watch/src/main/java/io/micronaut/discovery/consul/watch/watcher/BaseWatcherIntegrationTest.java
+++ b/test-suite-consul-watch/src/main/java/io/micronaut/discovery/consul/watch/watcher/BaseWatcherIntegrationTest.java
@@ -1,0 +1,163 @@
+package io.micronaut.discovery.consul.watch.watcher;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.consul.ConsulContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import io.micronaut.context.BeanContext;
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.context.annotation.Value;
+import io.micronaut.context.event.ApplicationEventListener;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.discovery.consul.watch.Watcher;
+import io.micronaut.runtime.context.scope.Refreshable;
+import io.micronaut.runtime.context.scope.refresh.RefreshEvent;
+import io.micronaut.test.support.TestPropertyProvider;
+
+@Testcontainers
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+abstract class BaseWatcherIntegrationTest implements TestPropertyProvider {
+
+    private static final Logger LOG = LoggerFactory.getLogger(BaseWatcherIntegrationTest.class);
+
+    protected static final String ROOT = "test/";
+
+    @Inject
+    private BeanContext beanContext;
+    @Inject
+    private TestEventListener testEventListener;
+    @Inject
+    private RefreshableBean refreshableBean;
+    @Inject
+    private RefreshableProperty refreshableProperty;
+    @Inject
+    private RefreshableInnerProperty refreshableInnerProperty;
+
+    @Container
+    protected static final ConsulContainer CONSUL_CONTAINER = new ConsulContainer("hashicorp/consul:1.18.1");
+
+    @Override
+    public @NonNull Map<String, String> getProperties() {
+        final var consulHost = CONSUL_CONTAINER.getHost();
+        final var consulPort = CONSUL_CONTAINER.getMappedPort(8500);
+        return Map.of(
+            "micronaut.application.name", "consul-watcher",
+            "micronaut.config-client.enabled", "true",
+            "consul.client.watch.enabled", "true",
+            "consul.client.blocking-queries.max-wait-duration", "5s",
+            "consul.client.config.path", "test",
+            "consul.client.host", consulHost,
+            "consul.client.port", String.valueOf(consulPort)
+        );
+    }
+
+    protected static void consulKvPut(final String key, final String data) throws Exception {
+        CONSUL_CONTAINER.execInContainer("consul", "kv", "put", key, data);
+    }
+
+    protected abstract void updateConsul(final String foo, final String bar) throws Exception;
+
+    @AfterEach
+    void cleanUp() {
+        CONSUL_CONTAINER.withConsulCommand("kv delete " + ROOT);
+    }
+
+    @Test
+    void should_refresh_only_updated_property() throws Exception {
+        // given
+        Awaitility.with()
+            .await()
+            .untilAsserted(() -> assertSoftly(softAssertions -> {
+                softAssertions.assertThat(refreshableProperty.getToBeUpdated()).isEqualTo("foo");
+                softAssertions.assertThat(refreshableInnerProperty.getKey().getToBeUpdated()).isEqualTo("foo");
+                softAssertions.assertThat(refreshableBean.keyToBeUpdated).isEqualTo("foo");
+                softAssertions.assertThat(refreshableBean.otherKey).isEqualTo("bar");
+
+                final var watcher = beanContext.getBean(Watcher.class);
+                softAssertions.assertThat(watcher.isWatching()).isTrue();
+            }));
+
+        // when
+        final var randomFoo = RandomStringUtils.secure().nextAlphanumeric(10);
+        updateConsul(randomFoo, "bar");
+
+        // then
+        Awaitility.with()
+            .await()
+            .atMost(2, SECONDS)
+            .untilAsserted(() -> assertSoftly(softAssertions -> {
+                softAssertions.assertThat(testEventListener.isEventReceived).as("isEventReceived").isTrue();
+                // refreshableProperty return the new value
+                softAssertions.assertThat(refreshableProperty.getToBeUpdated()).as("refreshableProperty").isEqualTo(randomFoo);
+                softAssertions.assertThat(refreshableInnerProperty.getKey().getToBeUpdated()).as("refreshableInnerProperty").isEqualTo(randomFoo);
+                // while current refreshableBean is not refreshed
+                softAssertions.assertThat(refreshableBean.keyToBeUpdated).as("refreshedBean").isEqualTo("foo");
+                softAssertions.assertThat(refreshableBean.otherKey).as("refreshedBean").isEqualTo("bar");
+                // but if we re-retrieve from the context, it has been recreated
+                final var refreshedBean = beanContext.getBean(RefreshableBean.class);
+                softAssertions.assertThat(refreshedBean.keyToBeUpdated).as("refreshedBean").isEqualTo(randomFoo);
+                softAssertions.assertThat(refreshedBean.otherKey).as("refreshedBean").isEqualTo("bar");
+            }));
+    }
+
+    @Singleton
+    public static class TestEventListener implements ApplicationEventListener<RefreshEvent> {
+
+        private final AtomicBoolean isEventReceived = new AtomicBoolean(false);
+
+        @Override
+        public void onApplicationEvent(final RefreshEvent event) {
+            LOG.info("Received refresh event: {}", event);
+            isEventReceived.set(true);
+        }
+    }
+
+    @ConfigurationProperties("my.key")
+    public interface RefreshableProperty {
+
+        @NotBlank
+        String getToBeUpdated();
+    }
+
+    @ConfigurationProperties("my")
+    public interface RefreshableInnerProperty {
+
+        @NotNull
+        InnerRefreshableProperty getKey();
+
+        @ConfigurationProperties("key")
+        interface InnerRefreshableProperty {
+
+            @NotBlank
+            String getToBeUpdated();
+        }
+    }
+
+    @Refreshable
+    public static class RefreshableBean {
+
+        @Value("${my.key.to_be_updated}")
+        public String keyToBeUpdated;
+
+        @Value("${an.other.property}")
+        public String otherKey;
+
+    }
+}

--- a/test-suite-consul-watch/src/main/java/io/micronaut/discovery/consul/watch/watcher/JsonWatcherIntegrationTest.java
+++ b/test-suite-consul-watch/src/main/java/io/micronaut/discovery/consul/watch/watcher/JsonWatcherIntegrationTest.java
@@ -1,0 +1,50 @@
+package io.micronaut.discovery.consul.watch.watcher;
+
+import org.intellij.lang.annotations.Language;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.micronaut.context.DefaultApplicationContextBuilder;
+import io.micronaut.context.annotation.Property;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+
+@Property(name = "consul.client.config.format", value = "json")
+@MicronautTest(contextBuilder = JsonWatcherIntegrationTest.CustomContextBuilder.class)
+class JsonWatcherIntegrationTest extends BaseWatcherIntegrationTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(JsonWatcherIntegrationTest.class);
+
+    public static class CustomContextBuilder extends DefaultApplicationContextBuilder {
+
+        public CustomContextBuilder() throws Exception {
+            LOG.info("Initializing consul...");
+            doUpdateConsul("foo", "bar");
+        }
+    }
+
+    @Language("JSON")
+    private static final String APPLICATION_JSON = """
+            {
+                "my.key.to_be_updated" : "%s",
+                "an.other.property" : "%s"
+            }""";
+
+    @Language("JSON")
+    private static final String TEST_JSON = """
+            {
+                "something.else" : "test"
+            }""";
+
+    @Override
+    protected void updateConsul(final String foo, final String bar) throws Exception{
+        LOG.info("Updating consul...");
+        doUpdateConsul(foo, bar);
+    }
+
+    private static void doUpdateConsul(final String foo, final String bar) throws Exception {
+        consulKvPut(ROOT + "application", String.format(APPLICATION_JSON, foo, bar));
+        consulKvPut(ROOT + "application,test", TEST_JSON);
+    }
+}
+
+

--- a/test-suite-consul-watch/src/main/java/io/micronaut/discovery/consul/watch/watcher/NativeWatcherIntegrationTest.java
+++ b/test-suite-consul-watch/src/main/java/io/micronaut/discovery/consul/watch/watcher/NativeWatcherIntegrationTest.java
@@ -1,0 +1,41 @@
+package io.micronaut.discovery.consul.watch.watcher;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.micronaut.context.DefaultApplicationContextBuilder;
+import io.micronaut.context.annotation.Property;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+
+@Property(name = "consul.client.config.format", value = "native")
+@MicronautTest(contextBuilder = NativeWatcherIntegrationTest.CustomContextBuilder.class)
+class NativeWatcherIntegrationTest extends BaseWatcherIntegrationTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(NativeWatcherIntegrationTest.class);
+
+    public static class CustomContextBuilder extends DefaultApplicationContextBuilder {
+
+        public CustomContextBuilder() throws Exception {
+            LOG.info("Initializing consul...");
+            doUpdateConsul("foo", "bar");
+        }
+    }
+
+    private static final String APPLICATION_PROPERTY_FOO = "my.key.to_be_updated";
+    private static final String APPLICATION_PROPERTY_BAR = "an.other.property";
+
+    @Override
+    protected void updateConsul(final String foo, final String bar) throws Exception {
+        LOG.info("Updating consul...");
+        doUpdateConsul(foo, bar);
+    }
+
+    private static void doUpdateConsul(final String foo, final String bar) throws Exception {
+        consulKvPut(ROOT + "application/" + APPLICATION_PROPERTY_FOO, foo);
+        consulKvPut(ROOT + "application/" + APPLICATION_PROPERTY_BAR, bar);
+        consulKvPut(ROOT + "application,test/something.else", "test");
+    }
+
+}
+
+

--- a/test-suite-consul-watch/src/main/java/io/micronaut/discovery/consul/watch/watcher/PropertiesHandlerIntegrationTest.java
+++ b/test-suite-consul-watch/src/main/java/io/micronaut/discovery/consul/watch/watcher/PropertiesHandlerIntegrationTest.java
@@ -1,0 +1,45 @@
+package io.micronaut.discovery.consul.watch.watcher;
+
+import org.intellij.lang.annotations.Language;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.micronaut.context.DefaultApplicationContextBuilder;
+import io.micronaut.context.annotation.Property;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+
+@Property(name = "consul.client.config.format", value = "properties")
+@MicronautTest(contextBuilder = PropertiesHandlerIntegrationTest.CustomContextBuilder.class)
+class PropertiesHandlerIntegrationTest extends BaseWatcherIntegrationTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PropertiesHandlerIntegrationTest.class);
+
+    public static class CustomContextBuilder extends DefaultApplicationContextBuilder {
+
+        public CustomContextBuilder() throws Exception {
+            LOG.info("Initializing consul...");
+            doUpdateConsul("foo", "bar");
+        }
+    }
+
+    @Language("PROPERTIES")
+    private static final String APPLICATION_PROPERTIES = """
+            my.key.to_be_updated=%s
+            an.other.property=%s""";
+    @Language("PROPERTIES")
+    private static final String TEST_PROPERTIES = "something.else=test";
+
+    @Override
+    protected void updateConsul(final String foo, final String bar) throws Exception {
+        LOG.info("Updating consul...");
+        doUpdateConsul(foo, bar);
+    }
+
+    private static void doUpdateConsul(final String foo, final String bar) throws Exception {
+        consulKvPut(ROOT + "application", String.format(APPLICATION_PROPERTIES, foo, bar));
+        consulKvPut(ROOT + "application,test", TEST_PROPERTIES);
+    }
+
+}
+
+

--- a/test-suite-consul-watch/src/main/java/io/micronaut/discovery/consul/watch/watcher/YamlWatcherIntegrationTest.java
+++ b/test-suite-consul-watch/src/main/java/io/micronaut/discovery/consul/watch/watcher/YamlWatcherIntegrationTest.java
@@ -1,0 +1,51 @@
+package io.micronaut.discovery.consul.watch.watcher;
+
+import org.intellij.lang.annotations.Language;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.micronaut.context.DefaultApplicationContextBuilder;
+import io.micronaut.context.annotation.Property;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+
+@Property(name = "consul.client.config.format", value = "yaml")
+@MicronautTest(contextBuilder = YamlWatcherIntegrationTest.CustomContextBuilder.class)
+class YamlWatcherIntegrationTest extends BaseWatcherIntegrationTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(YamlWatcherIntegrationTest.class);
+
+    public static class CustomContextBuilder extends DefaultApplicationContextBuilder {
+
+        public CustomContextBuilder() throws Exception {
+            LOG.info("Initializing consul...");
+            doUpdateConsul("foo", "bar");
+        }
+    }
+
+    @Language("YAML")
+    private static final String APPLICATION_YAML = """
+            my:
+              key:
+                to_be_updated: %s
+
+            an.other.property: %s""";
+
+    @Language("YAML")
+    private static final String TEST_YAML = """
+            something:
+              else: test""";
+
+    @Override
+    protected void updateConsul(final String foo, final String bar) throws Exception {
+        LOG.info("Updating consul...");
+        doUpdateConsul(foo, bar);
+    }
+
+    private static void doUpdateConsul(final String foo, final String bar) throws Exception {
+        consulKvPut(ROOT + "application", String.format(APPLICATION_YAML, foo, bar));
+        consulKvPut(ROOT + "application,test", TEST_YAML);
+    }
+
+}
+
+

--- a/test-suite-consul-watch/src/test/java/io/micronaut/discovery/consul/watch/watcher/ConsulWatchSuite.java
+++ b/test-suite-consul-watch/src/test/java/io/micronaut/discovery/consul/watch/watcher/ConsulWatchSuite.java
@@ -1,0 +1,11 @@
+package io.micronaut.discovery.consul.watch.watcher;
+
+import org.junit.platform.suite.api.SelectPackages;
+import org.junit.platform.suite.api.Suite;
+import org.junit.platform.suite.api.SuiteDisplayName;
+
+@Suite
+@SelectPackages("io.micronaut.discovery.consul.watch")
+@SuiteDisplayName("Consul Micronaut Watch")
+class ConsulWatchSuite {
+}

--- a/test-suite-consul-watch/src/test/resources/logback.xml
+++ b/test-suite-consul-watch/src/test/resources/logback.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%cyan(%d{HH:mm:ss.SSS}) %gray([%thread]) %highlight(%-5level) %magenta(%logger{36}) - %msg%n
+            </pattern>
+        </encoder>
+    </appender>
+
+    <logger name="io.micronaut.discovery.consul.watch" level="DEBUG"/>
+<!--    <logger name="io.micronaut.http.client" level="DEBUG"/>-->
+
+    <root level="info">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>


### PR DESCRIPTION
This new feature will allow the context to be refreshed when a change is detected in the KV used as distributed configurations.
The watch use the [Blocking Queries](https://developer.hashicorp.com/consul/api-docs/features/blocking) feature "to wait for a potential change using long polling"

1. Adding the `modifyIndex` field in the `KeyValue` class to be used for blocked queries
2. Creation of a new client that support the blocked queries by adding the `index` parameter, which can have the `wait` parameter set at the method level, and the query timeout calculated based on this `wait` parameter,
3. Creation of watchers, based of Consul configuration type (`JSON`, `YAML`, `PROPERTIES` and `NATIVE`)