### PR TITLE
Fix: Config server property source Deserealization

### DIFF
--- a/discovery-client/src/main/java/io/micronaut/discovery/spring/config/client/ConfigServerPropertySource.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/spring/config/client/ConfigServerPropertySource.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.ReflectiveAccess;
+import io.micronaut.serde.annotation.Serdeable;
 
 import java.util.Collections;
 import java.util.Map;
@@ -31,6 +32,7 @@ import java.util.Map;
  *  @since 1.1.0
  */
 @ReflectiveAccess
+@Serdeable
 public class ConfigServerPropertySource {
 
     private final String name;

--- a/discovery-client/src/main/java/io/micronaut/discovery/spring/config/client/ConfigServerResponse.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/spring/config/client/ConfigServerResponse.java
@@ -71,6 +71,10 @@ public class ConfigServerResponse {
         return propertySources;
     }
 
+    public void setPropertySources(List<ConfigServerPropertySource> propertySources) {
+        this.propertySources = propertySources;
+    }
+
     /**
      *
      * @return The name of the property source

--- a/test-suite-spring-cloud-config-server/src/test/java/io/micronaut/discovery/spring/config/ConfigServerPropertySourceTest.java
+++ b/test-suite-spring-cloud-config-server/src/test/java/io/micronaut/discovery/spring/config/ConfigServerPropertySourceTest.java
@@ -5,6 +5,7 @@ import io.micronaut.context.annotation.Property;
 import io.micronaut.core.beans.BeanIntrospection;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.StringUtils;
+import io.micronaut.discovery.spring.config.client.ConfigServerPropertySource;
 import io.micronaut.discovery.spring.config.client.ConfigServerResponse;
 import io.micronaut.json.JsonMapper;
 import io.micronaut.serde.SerdeIntrospections;
@@ -21,22 +22,23 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @Property(name = "micronaut.config-client.enabled", value = StringUtils.TRUE)
 @Property(name = "spring.cloud.config.enabled", value = StringUtils.TRUE)
 @MicronautTest(startApplication = false)
-class ConfigServerResponseTest {
+class ConfigServerPropertySourceTest {
     @Inject
     BeanContext beanContext;
+    private static final Class<ConfigServerPropertySource> CLAZZ = ConfigServerPropertySource.class;
+    private static final Argument<ConfigServerPropertySource> ARGUMENT_CLAZZ = Argument.of(CLAZZ);
 
     @Test
     void isAnnotatedWithSerdeable() {
         SerdeIntrospections serdeIntrospections = beanContext.getBean(SerdeIntrospections.class);
-        Assertions.assertDoesNotThrow(() -> serdeIntrospections.getDeserializableIntrospection(Argument.of(ConfigServerResponse.class)));
-        Assertions.assertDoesNotThrow(() -> serdeIntrospections.getSerializableIntrospection(Argument.of(ConfigServerResponse.class)));
+        Assertions.assertDoesNotThrow(() -> serdeIntrospections.getDeserializableIntrospection(ARGUMENT_CLAZZ));
+        Assertions.assertDoesNotThrow(() -> serdeIntrospections.getSerializableIntrospection(ARGUMENT_CLAZZ));
     }
 
     @Test
     void isAnnotatedWithIntrospected() {
-        assertDoesNotThrow(() -> BeanIntrospection.getIntrospection(ConfigServerResponse.class));
+        assertDoesNotThrow(() -> BeanIntrospection.getIntrospection(CLAZZ));
     }
-
 
     @Test
     void jsonDeserialization(JsonMapper jsonMapper) throws IOException {

--- a/test-suite-spring-cloud-config-server/src/test/java/io/micronaut/discovery/spring/config/ConfigServerPropertySourceTest.java
+++ b/test-suite-spring-cloud-config-server/src/test/java/io/micronaut/discovery/spring/config/ConfigServerPropertySourceTest.java
@@ -39,13 +39,4 @@ class ConfigServerPropertySourceTest {
     void isAnnotatedWithIntrospected() {
         assertDoesNotThrow(() -> BeanIntrospection.getIntrospection(CLAZZ));
     }
-
-    @Test
-    void jsonDeserialization(JsonMapper jsonMapper) throws IOException {
-        String json = """
-    {"name":"micronautguide","profiles":["spain"],"label":null,"version":"b071c1570f225343ac49823e67bdc85cba52ca1d","state":"","propertySources":[{"name":"https://github.com/sdelamo/spring-cloud-config-server-demo.git/micronautguide-spain.properties","source":{"vat.country":"Spain","vat.rate":"21"}},{"name":"https://github.com/sdelamo/spring-cloud-config-server-demo.git/micronautguide.properties","source":{"vat.country":"Switzerland","vat.rate":"7.7"}}]}""";
-        ConfigServerResponse configServerResponse = jsonMapper.readValue(json, ConfigServerResponse.class);
-        assertEquals(2, configServerResponse.getPropertySources().size());
-
-    }
 }

--- a/test-suite-spring-cloud-config-server/src/test/resources/logback.xml
+++ b/test-suite-spring-cloud-config-server/src/test/resources/logback.xml
@@ -1,0 +1,11 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>


### PR DESCRIPTION
Currently, it is impossible to deserialiaze `ConfigServerPropertySource` with Micronaut Serialization. `ConfigServerResponse` was missing a setter and `ConfigServerPropertySource` was not annotated with `@Serdeable`