### PR TITLE
Add a profiles configuration option

### DIFF
--- a/discovery-client/build.gradle
+++ b/discovery-client/build.gradle
@@ -7,6 +7,7 @@ dependencies {
     annotationProcessor(mn.micronaut.graal)
     annotationProcessor(mnValidation.micronaut.validation.processor)
     annotationProcessor(mnSerde.micronaut.serde.processor)
+    annotationProcessor(mn.micronaut.http.validation)
 
     api(mn.micronaut.discovery.core)
     api(mn.micronaut.json.core)

--- a/discovery-client/src/main/java/io/micronaut/discovery/spring/config/SpringCloudClientConfiguration.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/spring/config/SpringCloudClientConfiguration.java
@@ -26,6 +26,9 @@ import io.micronaut.http.client.HttpClientConfiguration;
 import io.micronaut.runtime.ApplicationConfiguration;
 
 import jakarta.inject.Inject;
+
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -57,6 +60,8 @@ public class SpringCloudClientConfiguration extends HttpClientConfiguration {
     private String name;
     private String username;
     private String password;
+
+    private List<String> profiles = new ArrayList<>();
 
     private final SpringCloudConnectionPoolConfiguration springCloudConnectionPoolConfiguration;
     private final SpringConfigDiscoveryConfiguration springConfigDiscoveryConfiguration = new SpringConfigDiscoveryConfiguration();
@@ -188,6 +193,24 @@ public class SpringCloudClientConfiguration extends HttpClientConfiguration {
     public void setPassword(@Nullable String password) {
         this.password = password;
     }
+
+    /**
+     * Profiles used to fetch configuration from the Spring Cloud Config Server. If not set by default, the profiles will be the value `default` plus the list of active micronaut environments.
+     * @return Profiles used to fetch configuration from the Spring Cloud Config Server
+     */
+    public List<String> getProfiles() {
+        return profiles;
+    }
+
+    /**
+     * Profiles used to fetch configuration from the Spring Cloud Config Server. If not set by default, the profiles will be the value `default` plus the list of active micronaut environments.
+     *
+     * @param profiles profiles
+     */
+    public void setProfiles(List<String> profiles) {
+        this.profiles = profiles;
+    }
+
 
     /**
      * The default connection pool configuration.

--- a/discovery-client/src/main/java/io/micronaut/discovery/spring/config/SpringCloudConfigurationClient.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/spring/config/SpringCloudConfigurationClient.java
@@ -24,8 +24,8 @@ import io.micronaut.context.exceptions.ConfigurationException;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.util.CollectionUtils;
-import io.micronaut.core.util.StringUtils;
 import io.micronaut.discovery.config.ConfigurationClient;
+import io.micronaut.discovery.spring.config.client.BlockingSpringCloudConfigClient;
 import io.micronaut.discovery.spring.config.client.SpringCloudConfigClient;
 import io.micronaut.discovery.spring.config.client.ConfigServerPropertySource;
 import io.micronaut.discovery.spring.config.client.ConfigServerResponse;
@@ -33,13 +33,14 @@ import io.micronaut.http.HttpStatus;
 import io.micronaut.http.client.exceptions.HttpClientResponseException;
 import io.micronaut.runtime.ApplicationConfiguration;
 import io.micronaut.scheduling.TaskExecutors;
+import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
 import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
-import reactor.core.scheduler.Schedulers;
+import reactor.core.publisher.Mono;
 
 import java.util.*;
 import java.util.concurrent.ExecutorService;
@@ -57,27 +58,60 @@ import java.util.concurrent.ExecutorService;
 public class SpringCloudConfigurationClient implements ConfigurationClient {
 
     private static final Logger LOG = LoggerFactory.getLogger(SpringCloudConfigurationClient.class);
+    private static final String DEFAULT_PROFILE = "default";
 
-    private final SpringCloudConfigClient springCloudConfigClient;
+    private final BlockingSpringCloudConfigClient springCloudConfigClient;
     private final SpringCloudClientConfiguration springCloudConfiguration;
     private final ApplicationConfiguration applicationConfiguration;
-    private ExecutorService executionService;
 
     /**
      * @param springCloudConfigClient  The Spring Cloud client
      * @param springCloudConfiguration The Spring Cloud configuration
      * @param applicationConfiguration The application configuration
      * @param executionService         The executor service to use
+     * @deprecated Use {@link #SpringCloudConfigurationClient(BlockingSpringCloudConfigClient, SpringCloudClientConfiguration, ApplicationConfiguration)} instead
      */
+    @Deprecated(forRemoval = true, since = "4.6.0")
     protected SpringCloudConfigurationClient(SpringCloudConfigClient springCloudConfigClient,
                                              SpringCloudClientConfiguration springCloudConfiguration,
                                              ApplicationConfiguration applicationConfiguration,
                                              @Named(TaskExecutors.IO) @Nullable ExecutorService executionService) {
+        this(new BlockingSpringCloudConfigClient() {
+            @Override
+            public ConfigServerResponse readValues(String applicationName, String profile) {
+                return Mono.from(springCloudConfigClient.readValues(applicationName, profile)).block();
+            }
+
+            @Override
+            public ConfigServerResponse readValuesAuthorized(String applicationName, String profile, String authorization) {
+                return Mono.from(springCloudConfigClient.readValues(applicationName, profile, authorization)).block();
+            }
+
+            @Override
+            public ConfigServerResponse readValues(String applicationName, String profile, String label) {
+                return Mono.from(springCloudConfigClient.readValues(applicationName, profile, label)).block();
+            }
+
+            @Override
+            public ConfigServerResponse readValuesAuthorized(String applicationName, String profile, String label, String authorization) {
+                return Mono.from(springCloudConfigClient.readValuesAuthorized(applicationName, profile, label, authorization)).block();
+            }
+        },  springCloudConfiguration, applicationConfiguration);
+    }
+
+    /**
+     * @param springCloudConfigClient  The Spring Cloud client
+     * @param springCloudConfiguration The Spring Cloud configuration
+     * @param applicationConfiguration The application configuration
+     */
+    @Inject
+    protected SpringCloudConfigurationClient(BlockingSpringCloudConfigClient springCloudConfigClient,
+                                             SpringCloudClientConfiguration springCloudConfiguration,
+                                             ApplicationConfiguration applicationConfiguration) {
 
         this.springCloudConfigClient = springCloudConfigClient;
         this.springCloudConfiguration = springCloudConfiguration;
         this.applicationConfiguration = applicationConfiguration;
-        this.executionService = executionService;
     }
 
     @Override
@@ -91,73 +125,86 @@ public class SpringCloudConfigurationClient implements ConfigurationClient {
             return Flux.empty();
         } else {
             String applicationName = springCloudConfiguration.getName().orElse(configuredApplicationName.get());
-            Set<String> activeNames = environment.getActiveNames();
-            String profiles = StringUtils.trimToNull(String.join(",", activeNames));
-
+            String label = springCloudConfiguration.getLabel();
+            List<String> profiles = profiles(environment);
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Spring Cloud Config Active: {}", springCloudConfiguration.getUri());
                 LOG.debug("Application Name: {}, Application Profiles: {}, label: {}", applicationName, profiles,
                          springCloudConfiguration.getLabel());
             }
 
-            String authorization = getAuthorization(springCloudConfiguration);
-            Publisher<ConfigServerResponse> responsePublisher;
-
-            if (authorization == null) {
-                responsePublisher =
-                    springCloudConfiguration.getLabel() == null ?
-                        springCloudConfigClient.readValues(applicationName, profiles) :
-                        springCloudConfigClient.readValues(applicationName,
-                            profiles, springCloudConfiguration.getLabel());
-            } else {
-                responsePublisher =
-                    springCloudConfiguration.getLabel() == null ?
-                        springCloudConfigClient.readValuesAuthorized(applicationName, profiles, authorization) :
-                        springCloudConfigClient.readValuesAuthorized(applicationName,
-                            profiles, springCloudConfiguration.getLabel(), authorization);
+            List<ConfigServerPropertySource> springSources = new ArrayList<>();
+            for (String profile : profiles) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Fetching Spring Cloud configuration for: {} profile: {} label {}", applicationName, profile, label);
+                }
+                List<ConfigServerPropertySource> profileConfigPropertySources = fetchPropertySources(applicationName, profile, label);
+                for (ConfigServerPropertySource profileConfigPropertySource :  profileConfigPropertySources) {
+                    if (springSources.stream().noneMatch(existing -> existing.getName().equals(profileConfigPropertySource.getName()))) {
+                        springSources.add(profileConfigPropertySource);
+                    }
+                }
             }
-
-            Flux<PropertySource> configurationValues = Flux.from(responsePublisher)
-                    .onErrorResume(throwable -> {
-                        if (throwable instanceof HttpClientResponseException httpClientResponseException && httpClientResponseException.getStatus() == HttpStatus.NOT_FOUND) {
-                            if (springCloudConfiguration.isFailFast()) {
-                                return Flux.error(
-                                    new ConfigurationException("Could not locate PropertySource and the fail fast property is set", throwable));
-                            } else {
-                                return Flux.empty();
-                            }
-                        }
-                        return Flux.error(new ConfigurationException("Error reading distributed configuration from Spring Cloud: " + throwable.getMessage(), throwable));
-                    })
-                    .flatMap(response -> {
-                        List<ConfigServerPropertySource> springSources = response.getPropertySources();
-                        if (CollectionUtils.isEmpty(springSources)) {
-                            return Flux.empty();
-                        }
-                        int baseOrder = EnvironmentPropertySource.POSITION + 100;
-                        List<PropertySource> propertySources = new ArrayList<>(springSources.size());
-                        //spring returns the property sources with the highest precedence first
-                        //reverse order and increment priority so the last (after reversed) item will
-                        //have the highest order
-                        for (int i = springSources.size() - 1; i >= 0; i--) {
-                            ConfigServerPropertySource springSource = springSources.get(i);
-                            propertySources.add(PropertySource.of(springSource.getName(), springSource.getSource(), ++baseOrder));
-                        }
-
-                        return Flux.fromIterable(propertySources);
-                    });
-
-            if (executionService != null) {
-                return configurationValues.subscribeOn(Schedulers.fromExecutor(executionService));
-            } else {
-                return configurationValues;
+            if (CollectionUtils.isEmpty(springSources)) {
+                return Flux.empty();
             }
+            int baseOrder = EnvironmentPropertySource.POSITION + 100;
+            List<PropertySource> propertySources = new ArrayList<>(springSources.size());
+            //spring returns the property sources with the highest precedence first
+            //reverse order and increment priority so the last (after reversed) item will
+            //have the highest order
+            for (int i = springSources.size() - 1; i >= 0; i--) {
+                ConfigServerPropertySource springSource = springSources.get(i);
+                propertySources.add(PropertySource.of(springSource.getName(), springSource.getSource(), ++baseOrder));
+            }
+            return Flux.fromIterable(propertySources);
         }
+    }
+
+    @NonNull
+    private List<String> profiles(@NonNull Environment environment) {
+        List<String> profiles = springCloudConfiguration.getProfiles();
+        if (CollectionUtils.isEmpty(profiles)) {
+            profiles.add(DEFAULT_PROFILE);
+            profiles.addAll(environment.getActiveNames());
+        }
+        return profiles;
+    }
+
+    private List<ConfigServerPropertySource> fetchPropertySources(@NonNull String applicationName, @NonNull String profile, @Nullable String label) {
+        try {
+            ConfigServerResponse response = invoke(applicationName, profile, label);
+            return response.getPropertySources();
+
+        } catch (Throwable throwable) {
+            if (throwable instanceof HttpClientResponseException httpClientResponseException && httpClientResponseException.getStatus() == HttpStatus.NOT_FOUND) {
+                if (springCloudConfiguration.isFailFast()) {
+                    throw new ConfigurationException("Could not locate PropertySource and the fail fast property is set", throwable);
+                }
+                return Collections.emptyList();
+            }
+            throw new ConfigurationException("Error reading distributed configuration from Spring Cloud: " + throwable.getMessage(), throwable);
+        }
+    }
+
+    private ConfigServerResponse invoke(@NonNull String applicationName, @NonNull String profile, @Nullable String label) {
+        String authorization = getAuthorization(springCloudConfiguration);
+        if (authorization == null) {
+            return
+                label == null ?
+                    springCloudConfigClient.readValues(applicationName, profile) :
+                    springCloudConfigClient.readValues(applicationName,
+                        profile, label);
+        }
+        return label == null ?
+                    springCloudConfigClient.readValuesAuthorized(applicationName, profile, authorization) :
+                    springCloudConfigClient.readValuesAuthorized(applicationName,
+                        profile, label, authorization);
     }
 
     @Override
     public final @NonNull String getDescription() {
-        return io.micronaut.discovery.spring.config.client.SpringCloudConfigClient.CLIENT_DESCRIPTION;
+        return io.micronaut.discovery.spring.config.client.BlockingSpringCloudConfigClient.CLIENT_DESCRIPTION;
     }
 
     /**

--- a/discovery-client/src/main/java/io/micronaut/discovery/spring/config/SpringCloudConfigurationClient.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/spring/config/SpringCloudConfigurationClient.java
@@ -63,6 +63,7 @@ public class SpringCloudConfigurationClient implements ConfigurationClient {
 
     private static final Logger LOG = LoggerFactory.getLogger(SpringCloudConfigurationClient.class);
     private static final String DEFAULT_PROFILE = "default";
+    public static final String COMMA = ",";
 
     private final BlockingSpringCloudConfigClient springCloudConfigClient;
     private final SpringCloudClientConfiguration springCloudConfiguration;
@@ -130,25 +131,17 @@ public class SpringCloudConfigurationClient implements ConfigurationClient {
         } else {
             String applicationName = springCloudConfiguration.getName().orElse(configuredApplicationName.get());
             String label = springCloudConfiguration.getLabel();
-            List<String> profiles = profiles(environment);
+            String profiles = String.join(COMMA, profiles(environment));
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Spring Cloud Config Active: {}", springCloudConfiguration.getUri());
                 LOG.debug("Application Name: {}, Application Profiles: {}, label: {}", applicationName, profiles,
                          springCloudConfiguration.getLabel());
             }
-
-            List<ConfigServerPropertySource> springSources = new ArrayList<>();
-            for (String profile : profiles) {
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("Fetching Spring Cloud configuration for: {} profile: {} label {}", applicationName, profile, label);
-                }
-                List<ConfigServerPropertySource> profileConfigPropertySources = fetchPropertySources(applicationName, profile, label);
-                for (ConfigServerPropertySource profileConfigPropertySource :  profileConfigPropertySources) {
-                    if (springSources.stream().noneMatch(existing -> existing.getName().equals(profileConfigPropertySource.getName()))) {
-                        springSources.add(profileConfigPropertySource);
-                    }
-                }
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Fetching Spring Cloud configuration for: {} profiles: {} label {}", applicationName, profiles, label);
             }
+            List<ConfigServerPropertySource> springSources = new ArrayList<>(fetchPropertySources(applicationName, profiles, label));
+
             if (CollectionUtils.isEmpty(springSources)) {
                 return Flux.empty();
             }
@@ -168,11 +161,14 @@ public class SpringCloudConfigurationClient implements ConfigurationClient {
     @NonNull
     private List<String> profiles(@NonNull Environment environment) {
         List<String> profiles = springCloudConfiguration.getProfiles();
-        if (CollectionUtils.isEmpty(profiles)) {
-            profiles.add(DEFAULT_PROFILE);
-            profiles.addAll(environment.getActiveNames());
+        if (!CollectionUtils.isEmpty(profiles)) {
+            return profiles;
         }
-        return profiles;
+        profiles = new ArrayList<>(environment.getActiveNames());
+        if (!CollectionUtils.isEmpty(profiles)) {
+            return profiles;
+        }
+        return Collections.singletonList(DEFAULT_PROFILE);
     }
 
     private List<ConfigServerPropertySource> fetchPropertySources(@NonNull String applicationName, @NonNull String profile, @Nullable String label) {

--- a/discovery-client/src/main/java/io/micronaut/discovery/spring/config/SpringCloudConfigurationClient.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/spring/config/SpringCloudConfigurationClient.java
@@ -48,6 +48,10 @@ import java.util.concurrent.ExecutorService;
 /**
  * A {@link ConfigurationClient} for Spring Cloud client.
  *
+ * NOTE: Because the {@link SpringCloudConfigClient} is invoked in a blocking fashion in  {@link io.micronaut.discovery.client.config.DistributedPropertySourceLocator},
+ * this class uses the blocking implementation of the Spring Cloud Config client - {@link BlockingSpringCloudConfigClient}. Thus, this implementation of {@link ConfigurationClient} is BLOCKING.
+ *
+ * @author Sergio del Amo
  * @author Thiago Locatelli
  * @author graemerocher
  * @since 1.0

--- a/discovery-client/src/main/java/io/micronaut/discovery/spring/config/SpringCloudConfigurationClient.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/spring/config/SpringCloudConfigurationClient.java
@@ -137,9 +137,6 @@ public class SpringCloudConfigurationClient implements ConfigurationClient {
                 LOG.debug("Application Name: {}, Application Profiles: {}, label: {}", applicationName, profiles,
                          springCloudConfiguration.getLabel());
             }
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Fetching Spring Cloud configuration for: {} profiles: {} label {}", applicationName, profiles, label);
-            }
             List<ConfigServerPropertySource> springSources = new ArrayList<>(fetchPropertySources(applicationName, profiles, label));
 
             if (CollectionUtils.isEmpty(springSources)) {

--- a/discovery-client/src/main/java/io/micronaut/discovery/spring/config/client/BlockingSpringCloudConfigClient.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/spring/config/client/BlockingSpringCloudConfigClient.java
@@ -22,6 +22,7 @@ import io.micronaut.core.annotation.Nullable;
 import io.micronaut.discovery.spring.config.SpringCloudClientConfiguration;
 import io.micronaut.http.annotation.Get;
 import io.micronaut.http.annotation.Header;
+import io.micronaut.http.annotation.PathVariable;
 import io.micronaut.http.annotation.Produces;
 import io.micronaut.http.client.annotation.Client;
 import io.micronaut.retry.annotation.Retryable;
@@ -43,7 +44,7 @@ public interface BlockingSpringCloudConfigClient {
      * Reads an application configuration from Spring Config Server.
      *
      * @param applicationName The application name
-     * @param profile profile
+     * @param profiles profiles
      * @return A {@link Publisher} that emits a list of {@link ConfigServerResponse}
      */
     @Get("/{applicationName}{/profiles}")
@@ -53,14 +54,14 @@ public interface BlockingSpringCloudConfigClient {
         delay = "${" + SpringCloudClientConfiguration.SpringConfigDiscoveryConfiguration.PREFIX + ".retry-delay:1s}"
     )
     ConfigServerResponse readValues(
-        @NonNull String applicationName,
-        @Nullable String profile);
+        @PathVariable @NonNull String applicationName,
+        @PathVariable @Nullable String profiles);
 
     /**
      * Reads an application configuration from Spring Config Server with authorization parameter.
      *
      * @param applicationName   The application name
-     * @param profile         profile
+     * @param profiles         profiles
      * @param authorization     The Basic authorization header needed to authorize against the server
      * @return A {@link Publisher} that emits a list of {@link ConfigServerResponse}
      */
@@ -71,15 +72,15 @@ public interface BlockingSpringCloudConfigClient {
             delay = "${" + SpringCloudClientConfiguration.SpringConfigDiscoveryConfiguration.PREFIX + ".retry-delay:1s}"
     )
     ConfigServerResponse readValuesAuthorized(
-            @NonNull String applicationName,
-            @Nullable String profile,
+            @PathVariable @NonNull String applicationName,
+            @PathVariable @Nullable String profiles,
             @Header String authorization);
 
     /**
      * Reads a versioned (#label) application configuration from Spring Config Server.
      *
      * @param applicationName   The application name
-     * @param profile           profile
+     * @param profiles           profiles
      * @param label             The label
      * @return A {@link Publisher} that emits a list of {@link ConfigServerResponse}
      */
@@ -90,15 +91,15 @@ public interface BlockingSpringCloudConfigClient {
         delay = "${" + SpringCloudClientConfiguration.SpringConfigDiscoveryConfiguration.PREFIX + ".retry-delay:1s}"
     )
     ConfigServerResponse readValues(
-        @NonNull String applicationName,
-        @Nullable String profile,
+        @PathVariable @NonNull String applicationName,
+        @PathVariable @Nullable String profiles,
         @Nullable String label);
 
     /**
      * Reads a versioned (#label) application configuration from Spring Config Server with authorization parameter.
      *
      * @param applicationName   The application name
-     * @param profile          profile
+     * @param profiles          profiles
      * @param label             The label
      * @param authorization     The Basic authorization header needed to authorize against the server
      * @return A {@link Publisher} that emits a list of {@link ConfigServerResponse}
@@ -110,8 +111,8 @@ public interface BlockingSpringCloudConfigClient {
             delay = "${" + SpringCloudClientConfiguration.SpringConfigDiscoveryConfiguration.PREFIX + ".retry-delay:1s}"
     )
     ConfigServerResponse readValuesAuthorized(
-            @NonNull String applicationName,
-            @Nullable String profile,
+            @PathVariable @NonNull String applicationName,
+            @PathVariable @Nullable String profiles,
             @Nullable String label,
             @Header String authorization);
 

--- a/discovery-client/src/main/java/io/micronaut/discovery/spring/config/client/BlockingSpringCloudConfigClient.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/spring/config/client/BlockingSpringCloudConfigClient.java
@@ -28,25 +28,22 @@ import io.micronaut.retry.annotation.Retryable;
 import org.reactivestreams.Publisher;
 
 /**
- * A non-blocking HTTP client for Spring Cloud Config Client.
+ * A blocking HTTP client for Spring Cloud Config Client.
  *
- * @author Thiago Locatelli
- * @since 1.0
- * @deprecated Not used. Use {@link BlockingSpringCloudConfigClient} instead.
+ * @author Sergio del Amo
+ * @since 4.6.0
  */
 @Client(value = SpringCloudClientConfiguration.SPRING_CLOUD_CONFIG_ENDPOINT, configuration = SpringCloudClientConfiguration.class)
 @BootstrapContextCompatible
 @Requires(beans = SpringCloudClientConfiguration.class)
-@Deprecated(forRemoval = true, since = "4.6.0")
-public interface SpringCloudConfigClient {
-
+public interface BlockingSpringCloudConfigClient {
     String CLIENT_DESCRIPTION = "spring-cloud-config-client";
 
     /**
      * Reads an application configuration from Spring Config Server.
      *
-     * @param applicationName   The application name
-     * @param profiles          The active profiles
+     * @param applicationName The application name
+     * @param profile profile
      * @return A {@link Publisher} that emits a list of {@link ConfigServerResponse}
      */
     @Get("/{applicationName}{/profiles}")
@@ -55,15 +52,15 @@ public interface SpringCloudConfigClient {
         attempts = "${" + SpringCloudClientConfiguration.SpringConfigDiscoveryConfiguration.PREFIX + ".retry-count:3}",
         delay = "${" + SpringCloudClientConfiguration.SpringConfigDiscoveryConfiguration.PREFIX + ".retry-delay:1s}"
     )
-    Publisher<ConfigServerResponse> readValues(
+    ConfigServerResponse readValues(
         @NonNull String applicationName,
-        @Nullable String profiles);
+        @Nullable String profile);
 
     /**
      * Reads an application configuration from Spring Config Server with authorization parameter.
      *
      * @param applicationName   The application name
-     * @param profiles          The active profiles
+     * @param profile         profile
      * @param authorization     The Basic authorization header needed to authorize against the server
      * @return A {@link Publisher} that emits a list of {@link ConfigServerResponse}
      */
@@ -73,16 +70,16 @@ public interface SpringCloudConfigClient {
             attempts = "${" + SpringCloudClientConfiguration.SpringConfigDiscoveryConfiguration.PREFIX + ".retry-count:3}",
             delay = "${" + SpringCloudClientConfiguration.SpringConfigDiscoveryConfiguration.PREFIX + ".retry-delay:1s}"
     )
-    Publisher<ConfigServerResponse> readValuesAuthorized(
+    ConfigServerResponse readValuesAuthorized(
             @NonNull String applicationName,
-            @Nullable String profiles,
+            @Nullable String profile,
             @Header String authorization);
 
     /**
      * Reads a versioned (#label) application configuration from Spring Config Server.
      *
      * @param applicationName   The application name
-     * @param profiles          The active profiles
+     * @param profile           profile
      * @param label             The label
      * @return A {@link Publisher} that emits a list of {@link ConfigServerResponse}
      */
@@ -92,16 +89,16 @@ public interface SpringCloudConfigClient {
         attempts = "${" + SpringCloudClientConfiguration.SpringConfigDiscoveryConfiguration.PREFIX + ".retry-count:3}",
         delay = "${" + SpringCloudClientConfiguration.SpringConfigDiscoveryConfiguration.PREFIX + ".retry-delay:1s}"
     )
-    Publisher<ConfigServerResponse> readValues(
+    ConfigServerResponse readValues(
         @NonNull String applicationName,
-        @Nullable String profiles,
+        @Nullable String profile,
         @Nullable String label);
 
     /**
      * Reads a versioned (#label) application configuration from Spring Config Server with authorization parameter.
      *
      * @param applicationName   The application name
-     * @param profiles          The active profiles
+     * @param profile          profile
      * @param label             The label
      * @param authorization     The Basic authorization header needed to authorize against the server
      * @return A {@link Publisher} that emits a list of {@link ConfigServerResponse}
@@ -112,9 +109,9 @@ public interface SpringCloudConfigClient {
             attempts = "${" + SpringCloudClientConfiguration.SpringConfigDiscoveryConfiguration.PREFIX + ".retry-count:3}",
             delay = "${" + SpringCloudClientConfiguration.SpringConfigDiscoveryConfiguration.PREFIX + ".retry-delay:1s}"
     )
-    Publisher<ConfigServerResponse> readValuesAuthorized(
+    ConfigServerResponse readValuesAuthorized(
             @NonNull String applicationName,
-            @Nullable String profiles,
+            @Nullable String profile,
             @Nullable String label,
             @Header String authorization);
 

--- a/discovery-client/src/main/java/io/micronaut/discovery/spring/config/client/ConfigServerResponse.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/spring/config/client/ConfigServerResponse.java
@@ -71,6 +71,10 @@ public class ConfigServerResponse {
         return propertySources;
     }
 
+    /**
+     *
+     * @param propertySources The list of property sources to be set
+     */
     public void setPropertySources(List<ConfigServerPropertySource> propertySources) {
         this.propertySources = propertySources;
     }

--- a/discovery-client/src/test/groovy/io/micronaut/discovery/spring/SpringCloudConfigTest.groovy
+++ b/discovery-client/src/test/groovy/io/micronaut/discovery/spring/SpringCloudConfigTest.groovy
@@ -43,11 +43,14 @@ class SpringCloudConfigTest extends Specification {
         ], "first", "second")
 
         expect:
-        1 == context.getRequiredProperty("config-secret-1", Integer.class)
-        1 == context.getRequiredProperty("config-secret-2", Integer.class)
-        1 == context.getRequiredProperty("config-secret-3", Integer.class)
-        1 == context.getRequiredProperty("config-secret-4", Integer.class)
+        // Coming from my-app with highest priority
+        5 == context.getRequiredProperty("config-secret-1", Integer.class)
+        4 == context.getRequiredProperty("config-secret-2", Integer.class)
+        3== context.getRequiredProperty("config-secret-3", Integer.class)
+        2 == context.getRequiredProperty("config-secret-4", Integer.class)
         1 == context.getRequiredProperty("config-secret-5", Integer.class)
+
+        // Coming from application it does not exist in my-app
         1 == context.getRequiredProperty("config-secret-6", Integer.class)
 
         cleanup:

--- a/discovery-client/src/test/groovy/io/micronaut/discovery/spring/SpringCloudConfigTest.groovy
+++ b/discovery-client/src/test/groovy/io/micronaut/discovery/spring/SpringCloudConfigTest.groovy
@@ -43,14 +43,11 @@ class SpringCloudConfigTest extends Specification {
         ], "first", "second")
 
         expect:
-        // Coming from my-app with highest priority
-        5 == context.getRequiredProperty("config-secret-1", Integer.class)
-        4 == context.getRequiredProperty("config-secret-2", Integer.class)
-        3== context.getRequiredProperty("config-secret-3", Integer.class)
-        2 == context.getRequiredProperty("config-secret-4", Integer.class)
+        1 == context.getRequiredProperty("config-secret-1", Integer.class)
+        1 == context.getRequiredProperty("config-secret-2", Integer.class)
+        1 == context.getRequiredProperty("config-secret-3", Integer.class)
+        1 == context.getRequiredProperty("config-secret-4", Integer.class)
         1 == context.getRequiredProperty("config-secret-5", Integer.class)
-
-        // Coming from application it does not exist in my-app
         1 == context.getRequiredProperty("config-secret-6", Integer.class)
 
         cleanup:


### PR DESCRIPTION
Currently, for Spring Cloud Server profiles path variable, we use Micronaut environments as comma separated. if no environment exists we use `default`. 

This pull-request: 

- Adds a `profiles` `List<String>` configuration option. If set, it will be used for Spring Cloud Server profiles path variable as a comma separated string.
- Adds  `BlockingSpringCloudConfigClient` - a blocking version of the Spring Cloud Config HTTP Client. 
- Rewrites the `SpringCloudConfigClient` to use the `BlockingSpringCloudConfigClient` to have simpler logic. Downstream [`DistributedPropertySourceLocator`](https://github.com/micronaut-projects/micronaut-discovery-client/blob/4.6.x/discovery-client/src/main/java/io/micronaut/discovery/client/config/DistributedPropertySourceLocator.java#L79) is blocking. 