### PR TITLE
Keep two arg constructor

### DIFF
--- a/discovery-client/src/main/java/io/micronaut/discovery/consul/client/v1/KeyValue.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/consul/client/v1/KeyValue.java
@@ -15,14 +15,15 @@
  */
 package io.micronaut.discovery.consul.client.v1;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+import io.micronaut.core.annotation.Creator;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.annotation.ReflectiveAccess;
 import io.micronaut.serde.annotation.Serdeable;
+import jakarta.inject.Inject;
 
 /**
  * Represents a Key/Value pair returned from Consul via /kv/:key.
@@ -34,21 +35,36 @@ import io.micronaut.serde.annotation.Serdeable;
 @Serdeable
 @ReflectiveAccess
 public class KeyValue {
-
-    private final Integer modifyIndex;
+    @JsonProperty("Key")
     private final String key;
+
+    @JsonProperty("Value")
     private final String value;
+
+    @Nullable
+    @JsonProperty("ModifyIndex")
+    private final Integer modifyIndex;
 
     /**
      * @param modifyIndex The KV index
      * @param key   The key
      * @param value The value
      */
-    @JsonCreator
-    public KeyValue(@Nullable @JsonProperty("ModifyIndex") Integer modifyIndex, @JsonProperty("Key") String key, @JsonProperty("Value") String value) {
-        this.modifyIndex = modifyIndex;
+    @Creator
+    public KeyValue(String key, String value, Integer modifyIndex) {
         this.key = key;
         this.value = value;
+        this.modifyIndex = modifyIndex;
+    }
+
+    /**
+     * @param key   The key
+     * @param value The value
+     * @deprecated Use {@link KeyValue#KeyValue(String, String, Integer)} instead.
+     */
+    @Deprecated(forRemoval = true, since = "4.6.0")
+    public KeyValue(String key, String value) {
+        this(key, value, null);
     }
 
     /**

--- a/discovery-client/src/main/java/io/micronaut/discovery/consul/watch/ConfigurationsWatcher.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/consul/watch/ConfigurationsWatcher.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import io.micronaut.core.annotation.Internal;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,6 +40,7 @@ import reactor.core.publisher.Mono;
  * @author LE GALL Benoît
  * @since 4.6.0
  */
+@Internal
 final class ConfigurationsWatcher extends AbstractWatcher<KeyValue> {
 
     private static final Logger LOG = LoggerFactory.getLogger(ConfigurationsWatcher.class);

--- a/discovery-client/src/main/java/io/micronaut/discovery/consul/watch/NativeWatcher.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/consul/watch/NativeWatcher.java
@@ -25,6 +25,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import io.micronaut.core.annotation.Internal;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,6 +42,7 @@ import reactor.core.publisher.Mono;
  * @author LE GALL Benoît
  * @since 4.6.0
  */
+@Internal
 final class NativeWatcher extends AbstractWatcher<List<KeyValue>> {
 
     private static final Logger LOG = LoggerFactory.getLogger(NativeWatcher.class);

--- a/discovery-client/src/main/java/io/micronaut/discovery/consul/watch/WatchFactory.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/consul/watch/WatchFactory.java
@@ -21,6 +21,7 @@ import static io.micronaut.discovery.config.ConfigDiscoveryConfiguration.DEFAULT
 import java.util.ArrayList;
 import java.util.List;
 
+import io.micronaut.core.annotation.Internal;
 import jakarta.inject.Singleton;
 
 import io.micronaut.context.annotation.Factory;
@@ -41,7 +42,8 @@ import io.micronaut.jackson.core.env.JsonPropertySourceLoader;
  * @since 4.6.0
  */
 @Factory
-public final class WatchFactory {
+@Internal
+final class WatchFactory {
 
     private static final String CONSUL_PATH_SEPARATOR = "/";
 
@@ -50,7 +52,7 @@ public final class WatchFactory {
     private final BlockingQueriesConfiguration blockingQueriesConfiguration;
     private final PropertiesChangeHandler propertiesChangeHandler;
 
-    public WatchFactory(final Environment environment,
+    WatchFactory(final Environment environment,
                         final BlockedQueriesConsulClient consulClient,
                         final BlockingQueriesConfiguration blockingQueriesConfiguration,
                         final PropertiesChangeHandler propertiesChangeHandler) {

--- a/discovery-client/src/test/groovy/io/micronaut/discovery/consul/MockConsulServer.groovy
+++ b/discovery-client/src/test/groovy/io/micronaut/discovery/consul/MockConsulServer.groovy
@@ -87,7 +87,7 @@ class MockConsulServer implements ConsulOperations {
                 folder = key.substring(0, i)
             }
             List<KeyValue> list = keyvalues.computeIfAbsent(folder, { String k -> []})
-            list.add(new KeyValue(RandomUtils.nextInt(), key, Base64.getEncoder().encodeToString(value.bytes)))
+            list.add(new KeyValue(key, Base64.getEncoder().encodeToString(value.bytes), RandomUtils.nextInt()))
         }
         return Flux.just(true)
     }

--- a/discovery-client/src/test/groovy/io/micronaut/discovery/consul/watch/KvUtilsSpec.groovy
+++ b/discovery-client/src/test/groovy/io/micronaut/discovery/consul/watch/KvUtilsSpec.groovy
@@ -16,11 +16,11 @@ class KvUtilsSpec extends Specification {
         where:
         left                            | right                             | expected
         null                            | null                              | true
-        new KeyValue(0, "key", "value") | null                              | false
-        null                            | new KeyValue(0, "key", "value")   | false
-        new KeyValue(0, "key", "value") | new KeyValue(0, "key_2", "value") | false
-        new KeyValue(0, "key", "value") | new KeyValue(0, "key", "value_2") | false
-        new KeyValue(0, "key", "value") | new KeyValue(0, "key", "value")   | true
+        new KeyValue("key", "value", 0) | null                              | false
+        null                            | new KeyValue("key", "value", 0)   | false
+        new KeyValue("key", "value", 0) | new KeyValue("key_2", "value", 0) | false
+        new KeyValue("key", "value", 0) | new KeyValue("key", "value_2", 0) | false
+        new KeyValue("key", "value", 0) | new KeyValue("key", "value", 0)   | true
     }
 
     void "test comparison between 2 lists of KeyValues"(final List<KeyValue> left, final List<KeyValue> right, final boolean expected) {
@@ -33,14 +33,14 @@ class KvUtilsSpec extends Specification {
         where:
         left                                                                           | right                                                                          | expected
         null                                                                           | null                                                                           | true
-        createList(new KeyValue(0, "key", "value"))                                    | null                                                                           | false
-        null                                                                           | createList(new KeyValue(0, "key", "value"))                                    | false
-        createList(new KeyValue(0, "key", "value"))                                    | createList(new KeyValue(0, "key_2", "value"))                                  | false
-        createList(new KeyValue(0, "key", "value"), new KeyValue(0, "key_2", "value")) | createList(new KeyValue(0, "key_2", "value"))                                  | false
-        createList(new KeyValue(0, "key", "value"))                                    | createList(new KeyValue(0, "key", "value"), new KeyValue(0, "key_2", "value")) | false
-        createList(new KeyValue(0, "key", "value"))                                    | createList(new KeyValue(0, "key", "value_2"))                                  | false
-        createList(new KeyValue(0, "key", "value"))                                    | createList(new KeyValue(0, "key", "value"))                                    | true
-        createList(new KeyValue(0, "key", "value"), new KeyValue(0, "key_2", "value")) | createList(new KeyValue(0, "key_2", "value"), new KeyValue(0, "key", "value")) | true
+        createList(new KeyValue("key", "value", 0))                                    | null                                                                           | false
+        null                                                                           | createList(new KeyValue( "key", "value", 0))                                    | false
+        createList(new KeyValue("key", "value", 0))                                    | createList(new KeyValue("key_2", "value", 0))                                  | false
+        createList(new KeyValue("key", "value", 0), new KeyValue("key_2", "value", 0)) | createList(new KeyValue("key_2", "value", 0))                                  | false
+        createList(new KeyValue("key", "value", 0))                                    | createList(new KeyValue("key", "value", 0), new KeyValue("key_2", "value", 0)) | false
+        createList(new KeyValue("key", "value", 0))                                    | createList(new KeyValue("key", "value_2", 0))                                  | false
+        createList(new KeyValue("key", "value", 0))                                    | createList(new KeyValue("key", "value", 0))                                    | true
+        createList(new KeyValue("key", "value", 0), new KeyValue("key_2", "value", 0)) | createList(new KeyValue("key_2", "value", 0), new KeyValue("key", "value", 0)) | true
     }
 
     private static List<KeyValue> createList(KeyValue... keyValues) {

--- a/discovery-client/src/test/groovy/io/micronaut/discovery/consul/watch/WatcherSpec.groovy
+++ b/discovery-client/src/test/groovy/io/micronaut/discovery/consul/watch/WatcherSpec.groovy
@@ -56,8 +56,8 @@ class WatcherSpec extends Specification {
 
         watcher = new ConfigurationsWatcher(List.of("path/to/yaml"), consulClient, watchConfiguration, propertiesChangeHandler, propertySourceReader)
 
-        def keyValue = new KeyValue(1234, "path/to/yaml", base64Encoder.encodeToString("foo.bar: value".getBytes()))
-        def newKeyValue = new KeyValue(4567, "path/to/yaml", base64Encoder.encodeToString("foo.bar: value_2".getBytes()))
+        def keyValue = new KeyValue("path/to/yaml", base64Encoder.encodeToString("foo.bar: value".getBytes()), 1234)
+        def newKeyValue = new KeyValue("path/to/yaml", base64Encoder.encodeToString("foo.bar: value_2".getBytes()), 4567)
 
         1 * consulClient.watchValues("path/to/yaml", false, null) >> Mono.just(List.of(keyValue)) // init
         2 * consulClient.watchValues("path/to/yaml", false, 1234) >>> [
@@ -114,12 +114,12 @@ class WatcherSpec extends Specification {
 
         watcher = new NativeWatcher(List.of("path/to/"), consulClient, watchConfiguration, propertiesChangeHandler)
 
-        def previousKeyValue1 = new KeyValue(12, "path/to/foo.bar", base64Encoder.encodeToString("value_a".getBytes()))
-        def previousKeyValue2 = new KeyValue(34, "path/to/other.key", base64Encoder.encodeToString("value_b".getBytes()))
+        def previousKeyValue1 = new KeyValue("path/to/foo.bar", base64Encoder.encodeToString("value_a".getBytes()), 12)
+        def previousKeyValue2 = new KeyValue("path/to/other.key", base64Encoder.encodeToString("value_b".getBytes()), 34)
         def previousKvs = new ArrayList<>(List.of(previousKeyValue1, previousKeyValue2))
 
-        def nextKeyValue1 = new KeyValue(56, "path/to/foo.bar", base64Encoder.encodeToString("value_c".getBytes()))
-        def nextKeyValue2 = new KeyValue(78, "path/to/other.key", base64Encoder.encodeToString("value_b".getBytes()))
+        def nextKeyValue1 = new KeyValue("path/to/foo.bar", base64Encoder.encodeToString("value_c".getBytes()), 56)
+        def nextKeyValue2 = new KeyValue("path/to/other.key", base64Encoder.encodeToString("value_b".getBytes()), 78)
         def nextKvs = new ArrayList<>(List.of(nextKeyValue1, nextKeyValue2))
 
         1 * consulClient.watchValues("path/to/", true, null) >> Mono.just(previousKvs) // init
@@ -183,8 +183,8 @@ class WatcherSpec extends Specification {
 
         watcher = new ConfigurationsWatcher(List.of("path/to/global_error"), consulClient, watchConfiguration, propertiesChangeHandler, propertySourceReader)
 
-        def keyValue = new KeyValue(0, "path/to/global_error", "")
-        def newKeyValue = new KeyValue(1, "path/to/global_error", "incorrect data")
+        def keyValue = new KeyValue("path/to/global_error", "", 0)
+        def newKeyValue = new KeyValue("path/to/global_error", "incorrect data", 1)
         1 * consulClient.watchValues("path/to/global_error", false, null) >> Mono.just(List.of(keyValue)) // init
         1 * consulClient.watchValues("path/to/global_error", false, 0) >> Mono.just(List.of(newKeyValue)) // change
 
@@ -404,7 +404,7 @@ class WatcherSpec extends Specification {
     void "test that stopping Watcher dispose all subscriptions"() {
         given:
         watcher = new ConfigurationsWatcher(List.of("path/to/yaml"), consulClient, watchConfiguration, propertiesChangeHandler, propertySourceReader)
-        def keyValue = new KeyValue(1234, "path/to/yaml", base64Encoder.encodeToString("foo.bar: value".getBytes()))
+        def keyValue = new KeyValue("path/to/yaml", base64Encoder.encodeToString("foo.bar: value".getBytes()), 1234)
 
         // fixme mock result to check the dispose call ?
         1 * consulClient.watchValues("path/to/yaml", false, null) >> Mono.delay(Duration.ofMillis(200))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ micronaut-validation = "4.9.0"
 micronaut-logging = "1.4.0"
 
 commons-lang3 = "3.17.0"
+jsonassert = "1.5.0"
 
 groovy = "4.0.17"
 spock = "2.3-groovy-4.0"
@@ -32,6 +33,7 @@ micronaut-docs-asciidoc-config-props = { module = "io.micronaut.docs:micronaut-d
 awaitility = { module = "org.awaitility:awaitility", version.ref = "awaitility" }
 
 commons-lang3 = { module = "org.apache.commons:commons-lang3", version.ref = "commons-lang3" }
+jsonassert = { module = "org.skyscreamer:jsonassert", version.ref = "jsonassert"}
 
 spock = { module = 'org.spockframework:spock-core', version.ref = "spock" }
 testcontainers-junit-jupiter = { module = "org.testcontainers:junit-jupiter"}

--- a/test-suite-consul-graal/build.gradle.kts
+++ b/test-suite-consul-graal/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
     implementation(libs.awaitility)
     implementation(platform(mnTestResources.boms.testcontainers))
     implementation(libs.testcontainers.junit.jupiter)
+    implementation(libs.jsonassert)
 }
 tasks.named("checkstyleMain").configure {
     enabled = false

--- a/test-suite-consul-graal/src/main/java/io/micronaut/consul/graal/KeyValueTest.java
+++ b/test-suite-consul-graal/src/main/java/io/micronaut/consul/graal/KeyValueTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.consul.graal;
+
+import io.micronaut.discovery.consul.client.v1.KeyValue;
+import io.micronaut.json.JsonMapper;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.json.JSONException;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@MicronautTest(startApplication = false)
+class KeyValueTest {
+
+    @Inject
+    JsonMapper jsonMapper;
+
+    @Test
+    void testJsonSerializationOfKeyValue() throws IOException, JSONException {
+        //given:
+        String expectedJson = "{\"Key\":\"foo\",\"Value\":\"bar\",\"ModifyIndex\":1}";
+
+        //when:
+        KeyValue value = new KeyValue("foo", "bar", 1);
+        String json = jsonMapper.writeValueAsString(value);
+
+        //then:
+        JSONAssert.assertEquals(
+            expectedJson, json, JSONCompareMode.LENIENT);
+
+        //when:
+        value = jsonMapper.readValue(expectedJson, KeyValue.class);
+
+        //then:
+        assertNotNull(value);
+        assertEquals(1, value.getModifyIndex());
+        assertEquals("foo", value.getKey());
+        assertEquals("bar", value.getValue());
+
+        //when:
+        value = new KeyValue("foo", "bar", null);
+        json = jsonMapper.writeValueAsString(value);
+
+        //then:
+        assertEquals("{\"Key\":\"foo\",\"Value\":\"bar\"}", json);
+    }
+}


### PR DESCRIPTION
This adds back the two arg constructor removed here: https://github.com/micronaut-projects/micronaut-discovery-client/pull/678

It adds test for serialization. 

Annotate some classes as internal. 