### PR TITLE
Consul AbstractWatcher now logs missing KV paths as WARN

### DIFF
--- a/discovery-client/src/main/java/io/micronaut/discovery/consul/watch/AbstractWatcher.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/consul/watch/AbstractWatcher.java
@@ -146,7 +146,7 @@ abstract sealed class AbstractWatcher<V> implements Watcher permits Configuratio
 
     private void onError(final String kvPath, final Throwable throwable) {
         if (throwable instanceof final HttpClientResponseException e && e.getStatus() == HttpStatus.NOT_FOUND) {
-            LOG.trace("No KV found with kvPath={}", kvPath);
+            LOG.warn("No KV found with kvPath={}", kvPath);
             listeners.remove(kvPath);
         } else if (throwable instanceof ReadTimeoutException) {
             LOG.warn("Timeout for kvPath={}", kvPath);


### PR DESCRIPTION
#765 