### PR TITLE
fix(consul): support secure HTTPS for micronaut.config.import

### DIFF
--- a/discovery-client/src/main/java/io/micronaut/discovery/consul/imports/ConsulPropertySourceImporter.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/consul/imports/ConsulPropertySourceImporter.java
@@ -47,6 +47,7 @@ public final class ConsulPropertySourceImporter extends RetryablePropertySourceI
     private static final String PROVIDER = "consul";
     private static final String CONSUL_HOST = ConsulConfiguration.PREFIX + ".host";
     private static final String CONSUL_PORT = ConsulConfiguration.PREFIX + ".port";
+    private static final String CONSUL_SECURE = ConsulConfiguration.PREFIX + ".secure";
     private static final String CONSUL_ACL_TOKEN = ConsulConfiguration.PREFIX + ".acl-token";
     private static final String CONSUL_CONFIG_FAIL_FAST = ConsulConfiguration.PREFIX + ".config.fail-fast";
 
@@ -91,6 +92,7 @@ public final class ConsulPropertySourceImporter extends RetryablePropertySourceI
         if (datacenter != null) {
             properties.put(ConsulConfiguration.PREFIX + ".config.datacenter", datacenter);
         }
+        values.get("secure", Boolean.class).ifPresent(v -> properties.put(CONSUL_SECURE, v));
         values.get("acl-token", String.class).ifPresent(v -> properties.put(CONSUL_ACL_TOKEN, v));
         values.get("fail-fast", Boolean.class).ifPresent(v -> properties.put(CONSUL_CONFIG_FAIL_FAST, v));
         values.get("read-timeout", String.class).ifPresent(v -> properties.put("micronaut.http.services.consul.read-timeout", v));
@@ -125,7 +127,9 @@ public final class ConsulPropertySourceImporter extends RetryablePropertySourceI
             String watchPath = importSupport.resolveWatchPath(importPath, format, imported).orElse(null);
             imported.put(WatchConfiguration.PREFIX + ".enabled", true);
             imported.putAll(properties.entrySet().stream()
-                .filter(e -> e.getKey().equals(CONSUL_HOST) || e.getKey().equals(CONSUL_PORT))
+                .filter(e -> e.getKey().equals(CONSUL_HOST)
+                    || e.getKey().equals(CONSUL_PORT)
+                    || e.getKey().equals(CONSUL_SECURE))
                 .collect(java.util.stream.Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
             if (watchPath != null) {
                 imported.put(WatchConfiguration.IMPORTED_PATHS, watchPath);

--- a/discovery-client/src/main/java/io/micronaut/discovery/imports/RemoteConfigImportOptionBinder.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/imports/RemoteConfigImportOptionBinder.java
@@ -59,6 +59,7 @@ public final class RemoteConfigImportOptionBinder {
             "format", "consul.client.config.format",
             "dc", "consul.client.config.datacenter",
             "acl-token", CONSUL_ACL_TOKEN,
+            "secure", "consul.client.secure",
             FAIL_FAST, "consul.client.config.fail-fast",
             "watch", "micronaut.discovery.consul.import.watch"
         ),

--- a/discovery-client/src/test/groovy/io/micronaut/discovery/consul/ConsulPropertySourceImporterSpec.groovy
+++ b/discovery-client/src/test/groovy/io/micronaut/discovery/consul/ConsulPropertySourceImporterSpec.groovy
@@ -150,6 +150,43 @@ class ConsulPropertySourceImporterSpec extends Specification {
         declaration.properties()['consul.client.config.fail-fast'] == true
     }
 
+    void 'consul importer map configuration binds secure for HTTPS'() {
+        given:
+        def importer = new ConsulPropertySourceImporter()
+
+        when:
+        def declaration = importer.newImportDeclaration(ConvertibleValues.of([
+            host: 'localhost',
+            port: 8501,
+            path: 'config/application',
+            secure: true
+        ]), null)
+
+        then:
+        declaration.properties()['consul.client.host'] == 'localhost'
+        declaration.properties()['consul.client.port'] == 8501
+        declaration.properties()['consul.client.secure'] == true
+    }
+
+    void 'consul importer connection string binds secure for HTTPS'() {
+        given:
+        def importer = new ConsulPropertySourceImporter()
+        def connectionString = io.micronaut.core.util.ConnectionString.parse(
+            'consul://localhost:8501/config/micronaut/application?format=yaml&watch=true&secure=true'
+        )
+
+        when:
+        def declaration = importer.newImportDeclaration(connectionString, null)
+
+        then:
+        declaration.properties()['consul.client.host'] == 'localhost'
+        declaration.properties()['consul.client.port'] == 8501
+        declaration.properties()['consul.client.secure'] == 'true'
+        declaration.properties()['consul.client.config.format'] == 'yaml'
+        declaration.watchEnabled()
+        declaration.path() == 'config/micronaut/application'
+    }
+
     void 'consul importer normalizes yml watch format to YAML'() {
         given:
         def importer = new ConsulPropertySourceImporter()

--- a/discovery-client/src/test/groovy/io/micronaut/discovery/imports/RemoteConfigImportOptionsSpec.groovy
+++ b/discovery-client/src/test/groovy/io/micronaut/discovery/imports/RemoteConfigImportOptionsSpec.groovy
@@ -36,10 +36,11 @@ class RemoteConfigImportOptionsSpec extends Specification {
 
     void 'binds provider-specific options for each supported protocol'() {
         expect:
-        binder.bind(ConnectionString.parse('consul://localhost:8500/config/application?format=json&dc=dc1&acl-token=token&fail-fast=true')) == [
+        binder.bind(ConnectionString.parse('consul://localhost:8500/config/application?format=json&dc=dc1&acl-token=token&secure=true&fail-fast=true')) == [
             'consul.client.config.format': 'json',
             'consul.client.config.datacenter': 'dc1',
             'consul.client.acl-token': 'token',
+            'consul.client.secure': 'true',
             'consul.client.config.fail-fast': 'true'
         ]
 

--- a/src/main/docs/guide/distributedConfigurationConsulConsulImportUriReference.adoc
+++ b/src/main/docs/guide/distributedConfigurationConsulConsulImportUriReference.adoc
@@ -41,6 +41,10 @@
 |`?acl-token=token`
 |Consul ACL token. Prefer URI user-info instead.
 
+|`secure`
+|`?secure=true`
+|Use HTTPS when connecting to Consul (`consul.client.secure`). Required for TLS-only Consul listeners (for example port `8501`).
+
 |`fail-fast`
 |`?fail-fast=false`
 |Whether failures should abort startup immediately.

--- a/src/main/docs/guide/distributedConfigurationConsulImportingConsulConfiguration.adoc
+++ b/src/main/docs/guide/distributedConfigurationConsulImportingConsulConfiguration.adoc
@@ -52,4 +52,14 @@ micronaut:
 
 When `watch=true` is used, Consul change notifications trigger an environment refresh so the imported configuration is reloaded and a `RefreshEvent` is published.
 
+For Consul agents that expose the HTTP API only over TLS, set `secure=true` so the importer uses HTTPS:
+
+.Importing Consul configuration over HTTPS
+[configuration]
+----
+micronaut:
+  config:
+    import: "consul://localhost:8501/config/application?format=yaml&secure=true"
+----
+
 Treat import URIs with embedded credentials as sensitive values and store them accordingly.


### PR DESCRIPTION
## Description

Fixes https://github.com/micronaut-projects/micronaut-discovery-client/issues/889

`micronaut.config.import` for Consul only applied `consul.client.host` / `consul.client.port` from the import URI. The importer child context never set `consul.client.secure`, so TLS-only Consul agents (commonly port `8501`) were contacted with plain HTTP via `DiscoveryServerInstanceList`, which surfaces as:

```
Client 'consul': Bad Request
```

### Changes

- Bind query option `secure` → `consul.client.secure` in `RemoteConfigImportOptionBinder` for the `consul` provider
- Bind map-style import key `secure` in `ConsulPropertySourceImporter`
- When `watch=true`, also propagate `consul.client.secure` into the imported watch client properties (alongside host/port)
- Document `?secure=true` in the Consul import guide / URI reference

### Usage

```yaml
micronaut:
  config:
    import: "consul://localhost:8501/config/micronaut/application?format=yaml&secure=true&watch=true"
```

Self-signed / custom CA setups still need normal Micronaut HTTP client SSL configuration (for example `micronaut.http.services.consul.ssl.*`); this change only selects the HTTPS scheme.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added documentation (if appropriate)
- [x] I have updated the related Micronaut module documentation (if appropriate)
- [x] I have updated related Gradle build files (if appropriate)

## Testing

```bash
./gradlew :micronaut-discovery-client:test \
  --tests 'io.micronaut.discovery.imports.RemoteConfigImportOptionsSpec' \
  --tests 'io.micronaut.discovery.consul.ConsulPropertySourceImporterSpec' \
  --tests 'io.micronaut.discovery.consul.imports.ConsulImportSupportSpec'
```

Result: **18/18 passed** (no live Consul; unit/importer tests only)