### PR TITLE
Guard Consul watch beans on Consul configuration

### DIFF
--- a/discovery-client/src/main/java/io/micronaut/discovery/consul/watch/WatchFactory.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/consul/watch/WatchFactory.java
@@ -32,6 +32,7 @@ import io.micronaut.context.env.PropertySourceLoader;
 import io.micronaut.context.env.yaml.YamlPropertySourceLoader;
 import io.micronaut.context.exceptions.ConfigurationException;
 import io.micronaut.discovery.consul.ConsulConfiguration;
+import io.micronaut.discovery.consul.condition.RequiresConsul;
 import io.micronaut.discovery.imports.RemoteConfigImportMetadata;
 import io.micronaut.discovery.consul.client.v1.blockingqueries.BlockingQueriesConfiguration;
 import io.micronaut.discovery.consul.client.v1.blockingqueries.BlockedQueriesConsulClient;
@@ -46,6 +47,7 @@ import io.micronaut.jackson.core.env.JsonPropertySourceLoader;
  */
 @Factory
 @Internal
+@RequiresConsul
 final class WatchFactory {
 
     private static final String CONSUL_PATH_SEPARATOR = "/";

--- a/discovery-client/src/main/java/io/micronaut/discovery/consul/watch/WatchTrigger.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/consul/watch/WatchTrigger.java
@@ -21,6 +21,7 @@ import org.slf4j.LoggerFactory;
 import io.micronaut.context.annotation.Prototype;
 import io.micronaut.context.event.ShutdownEvent;
 import io.micronaut.context.event.StartupEvent;
+import io.micronaut.discovery.consul.condition.RequiresConsul;
 import io.micronaut.runtime.event.annotation.EventListener;
 
 /**
@@ -30,6 +31,7 @@ import io.micronaut.runtime.event.annotation.EventListener;
  * @since 4.6.0
  */
 @Prototype
+@RequiresConsul
 final class WatchTrigger {
 
     private static final Logger LOG = LoggerFactory.getLogger(WatchTrigger.class);

--- a/discovery-client/src/test/groovy/io/micronaut/discovery/consul/watch/WatchBeanConditionSpec.groovy
+++ b/discovery-client/src/test/groovy/io/micronaut/discovery/consul/watch/WatchBeanConditionSpec.groovy
@@ -1,0 +1,13 @@
+package io.micronaut.discovery.consul.watch
+
+import io.micronaut.discovery.consul.condition.RequiresConsul
+import spock.lang.Specification
+
+class WatchBeanConditionSpec extends Specification {
+
+    void "watch beans declare the consul condition directly"() {
+        expect:
+        WatchFactory.getAnnotation(RequiresConsul) != null
+        WatchTrigger.getAnnotation(RequiresConsul) != null
+    }
+}


### PR DESCRIPTION
Apply the existing Consul condition directly to the watch factory and trigger. This prevents those beans from being created when Consul is disabled or not configured.

Tests:
`./gradlew :micronaut-discovery-client:test --tests io.micronaut.discovery.consul.watch.WatchBeanConditionSpec --rerun-tasks --stacktrace`