### PR TITLE
Keep Consul addresses as the strings Consul sends

### DIFF
--- a/discovery-client-tests/src/test/groovy/io/micronaut/discovery/consul/ConsulAddressSerdeSpec.groovy
+++ b/discovery-client-tests/src/test/groovy/io/micronaut/discovery/consul/ConsulAddressSerdeSpec.groovy
@@ -1,0 +1,87 @@
+package io.micronaut.discovery.consul
+
+import io.micronaut.core.type.Argument
+import io.micronaut.discovery.consul.client.v1.ConsulCatalogEntry
+import io.micronaut.discovery.consul.client.v1.ConsulHealthEntry
+import io.micronaut.discovery.consul.client.v1.MemberEntry
+import io.micronaut.discovery.consul.client.v1.NodeEntry
+import io.micronaut.json.JsonMapper
+import io.micronaut.serde.ObjectMapper
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+/**
+ * Consul addresses may be host names. With Micronaut Serialization they must be read and written
+ * as strings, like with Jackson Databind.
+ */
+@MicronautTest(startApplication = false)
+class ConsulAddressSerdeSpec extends Specification {
+
+    // the .invalid top level domain never resolves, so a lookup during deserialization would fail
+    static final String HOST = 'consul-node.invalid'
+
+    @Inject
+    JsonMapper jsonMapper
+
+    void "the JSON mapper is Micronaut Serialization"() {
+        expect:
+        jsonMapper instanceof ObjectMapper
+    }
+
+    void "a health entry with a host name node address is read and written unchanged"() {
+        given:
+        String json = """[{
+  "Node": {"Node": "foobar", "Address": "$HOST", "Datacenter": "dc1"},
+  "Service": {"ID": "redis", "Service": "redis", "Port": 8000},
+  "Checks": []
+}]"""
+
+        when:
+        List<ConsulHealthEntry> entries = jsonMapper.readValue(json, Argument.listOf(ConsulHealthEntry))
+
+        then:
+        entries.size() == 1
+        entries[0].node().address() == HOST
+        new ConsulServiceInstance(entries[0], 'http').URI == URI.create("http://$HOST:8000")
+
+        when:
+        String output = jsonMapper.writeValueAsString(entries[0].node())
+
+        then:
+        output.contains(/"Address":"$HOST"/)
+        jsonMapper.readValue(output, ConsulCatalogEntry) == entries[0].node()
+    }
+
+    void "a member with a host name address is read and written unchanged"() {
+        when:
+        MemberEntry member = jsonMapper.readValue(/{"Name": "foobar", "Addr": "$HOST", "Port": 8301, "Status": 1}/, MemberEntry)
+
+        then:
+        member.hostString == HOST
+        member.port == 8301
+
+        when:
+        String output = jsonMapper.writeValueAsString(member)
+
+        then:
+        output.contains(/"Addr":"$HOST"/)
+        !output.contains('"Address"')
+    }
+
+    void "a node entry with a host name address is read and written unchanged"() {
+        when:
+        NodeEntry node = jsonMapper.readValue(/{"Node": "foobar", "Address": "$HOST"}/, NodeEntry)
+
+        then:
+        node.node == 'foobar'
+        node.hostString == HOST
+
+        when:
+        String output = jsonMapper.writeValueAsString(node)
+
+        then:
+        output.contains(/"Address":"$HOST"/)
+        output.count('Address') == 1
+    }
+}

--- a/discovery-client/src/main/java/io/micronaut/discovery/consul/ConsulServiceInstance.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/consul/ConsulServiceInstance.java
@@ -64,7 +64,8 @@ public class ConsulServiceInstance implements ServiceInstance {
         ConsulCatalogEntry node = healthEntry.node();
         Objects.requireNonNull(service, "ConsulHealthEntry cannot reference a null node entry");
 
-        String inetAddress = service.address() != null ? service.address() : node.address().getHostAddress();
+        // Consul sends host names or IP literals, use them as they are
+        String inetAddress = service.address() != null ? service.address() : node.address();
         int port = service.port() != null ? service.port() : -1;
         String portSuffix = port > -1 ? ":" + port : "";
         String uriStr = (scheme != null ? scheme + "://" : "http://") + inetAddress + portSuffix;

--- a/discovery-client/src/main/java/io/micronaut/discovery/consul/client/v1/AbstractServiceEntry.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/consul/client/v1/AbstractServiceEntry.java
@@ -15,15 +15,14 @@
  */
 package io.micronaut.discovery.consul.client.v1;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import tools.jackson.databind.PropertyNamingStrategies;
 import tools.jackson.databind.annotation.JsonNaming;
 import io.micronaut.core.annotation.Introspected;
 import io.micronaut.core.annotation.ReflectiveAccess;
-import io.micronaut.http.client.exceptions.HttpClientException;
 
 import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -43,7 +42,7 @@ import java.util.OptionalInt;
 public abstract class AbstractServiceEntry {
 
     protected final String name;
-    private InetAddress address;
+    private String hostString;
     private Integer port;
     private List<String> tags;
     private String ID;
@@ -79,19 +78,50 @@ public abstract class AbstractServiceEntry {
     /**
      * See https://www.consul.io/api/agent/service.html#address.
      *
-     * @return The address of the service
+     * @return The address of the service, a host name or an IP literal. It is not resolved.
+     * @since 5.2.0
      */
-    public Optional<InetAddress> getAddress() {
-        return Optional.ofNullable(address);
+    @JsonProperty("Address")
+    public Optional<String> getHostString() {
+        return Optional.ofNullable(hostString);
     }
 
     /**
      * See https://www.consul.io/api/agent/service.html#address.
      *
+     * @param hostString The address of the service, a host name or an IP literal
+     * @since 5.2.0
+     */
+    @JsonProperty("Address")
+    public void setHostString(String hostString) {
+        this.hostString = hostString;
+    }
+
+    /**
+     * See https://www.consul.io/api/agent/service.html#address.
+     *
+     * <p>The address is resolved on each call, which needs a DNS lookup when it is a host name.</p>
+     *
+     * @return The resolved address of the service
+     * @throws java.io.UncheckedIOException if the host name cannot be resolved
+     * @deprecated Use {@link #getHostString()} and resolve the address where it is needed.
+     */
+    @Deprecated(since = "5.2.0", forRemoval = true)
+    @JsonIgnore
+    public Optional<InetAddress> getAddress() {
+        return Optional.ofNullable(ConsulAddresses.resolve(hostString));
+    }
+
+    /**
+     * See https://www.consul.io/api/agent/service.html#address.
+     *
+     * <p>The address is stored as its host name, or as its IP literal when it has no host name.</p>
+     *
      * @param address The address of the service
      */
+    @JsonIgnore
     public void setAddress(InetAddress address) {
-        this.address = address;
+        this.hostString = ConsulAddresses.toHostString(address);
     }
 
     /**
@@ -177,24 +207,24 @@ public abstract class AbstractServiceEntry {
     }
 
     /**
-     * @param address The {@link InetAddress } of the service
+     * @param address The {@link InetAddress } of the service, stored as its host name, or as its IP
+     *                literal when it has no host name
      * @return The {@link AbstractServiceEntry} instance
      */
     public AbstractServiceEntry address(InetAddress address) {
-        this.address = address;
+        this.hostString = ConsulAddresses.toHostString(address);
         return this;
     }
 
     /**
-     * @param address The address of the service
+     * Sets the address as given. Since 5.2.0 it is no longer resolved, so a host name is sent to
+     * Consul unchanged.
+     *
+     * @param address The address of the service, a host name or an IP literal
      * @return The {@link AbstractServiceEntry} instance
      */
     public AbstractServiceEntry address(String address) {
-        try {
-            this.address = InetAddress.getByName(address);
-        } catch (UnknownHostException e) {
-            throw new HttpClientException(e.getMessage(), e);
-        }
+        this.hostString = address;
         return this;
     }
 
@@ -236,7 +266,7 @@ public abstract class AbstractServiceEntry {
         }
         AbstractServiceEntry that = (AbstractServiceEntry) o;
         return Objects.equals(name, that.name) &&
-            Objects.equals(address, that.address) &&
+            Objects.equals(hostString, that.hostString) &&
             Objects.equals(port, that.port) &&
             Objects.equals(tags, that.tags) &&
             Objects.equals(meta, that.meta) &&
@@ -245,6 +275,6 @@ public abstract class AbstractServiceEntry {
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, address, port, tags, meta, ID);
+        return Objects.hash(name, hostString, port, tags, meta, ID);
     }
 }

--- a/discovery-client/src/main/java/io/micronaut/discovery/consul/client/v1/ConsulAddresses.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/consul/client/v1/ConsulAddresses.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.discovery.consul.client.v1;
+
+import org.jspecify.annotations.Nullable;
+
+import java.io.UncheckedIOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+/**
+ * Converts between the address strings Consul sends and {@link InetAddress}.
+ *
+ * <p>Consul addresses may be host names or IP literals. The models keep them as strings, so the
+ * JSON library never has to turn them into an {@link InetAddress}.</p>
+ *
+ * @since 5.2.0
+ */
+final class ConsulAddresses {
+
+    private ConsulAddresses() {
+    }
+
+    /**
+     * Returns the host name of the address, or its IP literal when it has no host name. This is
+     * the value Jackson writes for an {@link InetAddress}, and it does not trigger a reverse lookup.
+     *
+     * @param address The address
+     * @return The host string, or {@code null} for a {@code null} address
+     */
+    static @Nullable String toHostString(@Nullable InetAddress address) {
+        if (address == null) {
+            return null;
+        }
+        String value = address.toString().trim();
+        int slash = value.indexOf('/');
+        if (slash > 0) {
+            return value.substring(0, slash);
+        }
+        return address.getHostAddress();
+    }
+
+    /**
+     * Resolves a Consul address, which may need a DNS lookup when it is a host name.
+     *
+     * @param hostString The host name or IP literal
+     * @return The resolved address, or {@code null} for a {@code null} or empty value
+     * @throws UncheckedIOException if the host name cannot be resolved
+     */
+    static @Nullable InetAddress resolve(@Nullable String hostString) {
+        if (hostString == null || hostString.isEmpty()) {
+            return null;
+        }
+        try {
+            return InetAddress.getByName(hostString);
+        } catch (UnknownHostException e) {
+            throw new UncheckedIOException("Failed to resolve Consul address [" + hostString + "]: " + e.getMessage(), e);
+        }
+    }
+}

--- a/discovery-client/src/main/java/io/micronaut/discovery/consul/client/v1/ConsulCatalogEntry.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/consul/client/v1/ConsulCatalogEntry.java
@@ -27,7 +27,7 @@ import java.util.Map;
  * @see <a href="https://developer.hashicorp.com/consul/api-docs/catalog#sample-payload">Catalog Sample Payload</a>.
  *
  * @param node Node ID
- * @param address Address
+ * @param address Address as sent by Consul, a host name or an IP literal. It is not resolved.
  * @param datacenter Datacenter
  * @param taggedAddresses Tagged addresses
  * @param nodeMetadata Node metadata
@@ -38,9 +38,31 @@ import java.util.Map;
  */
 @Serdeable
 public record ConsulCatalogEntry(@Nullable @JsonProperty("Node") String node,
-                                 @Nullable @JsonProperty("Address") InetAddress address,
+                                 @Nullable @JsonProperty("Address") String address,
                                  @Nullable @JsonProperty("Datacenter") String datacenter,
                                  @Nullable @JsonProperty("TaggedAddresses") Map<String, String> taggedAddresses,
                                  @Nullable @JsonProperty("NodeMeta") Map<String, String> nodeMetadata,
                                  @Nullable @JsonProperty("Service") ConsulNewServiceEntry service) {
+
+    /**
+     * Creates a catalog entry from an {@link InetAddress}. The address is stored as its host name,
+     * or as its IP literal when it has no host name.
+     *
+     * @param node Node ID
+     * @param address Address
+     * @param datacenter Datacenter
+     * @param taggedAddresses Tagged addresses
+     * @param nodeMetadata Node metadata
+     * @param service Service
+     * @deprecated Use the canonical constructor, which takes the address as a string.
+     */
+    @Deprecated(since = "5.2.0", forRemoval = true)
+    public ConsulCatalogEntry(@Nullable String node,
+                              @Nullable InetAddress address,
+                              @Nullable String datacenter,
+                              @Nullable Map<String, String> taggedAddresses,
+                              @Nullable Map<String, String> nodeMetadata,
+                              @Nullable ConsulNewServiceEntry service) {
+        this(node, ConsulAddresses.toHostString(address), datacenter, taggedAddresses, nodeMetadata, service);
+    }
 }

--- a/discovery-client/src/main/java/io/micronaut/discovery/consul/client/v1/MemberEntry.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/consul/client/v1/MemberEntry.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.discovery.consul.client.v1;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import tools.jackson.databind.PropertyNamingStrategies;
 import tools.jackson.databind.annotation.JsonNaming;
@@ -34,7 +35,7 @@ import java.util.Map;
 public class MemberEntry {
 
     private String name;
-    private InetAddress address;
+    private String hostString;
     private Integer port;
     private Map<String, String> tags;
     private Integer status;
@@ -54,18 +55,44 @@ public class MemberEntry {
     }
 
     /**
-     * @return The {@link InetAddress} of this member
+     * @return The address of this member as sent by Consul, a host name or an IP literal. It is not resolved.
+     * @since 5.2.0
      */
-    public InetAddress getAddress() {
-        return address;
+    @JsonProperty("Addr")
+    public String getHostString() {
+        return hostString;
     }
 
     /**
-     * @param address The {@link InetAddress} of this member
+     * @param hostString The address of this member, a host name or an IP literal
+     * @since 5.2.0
      */
     @JsonProperty("Addr")
+    public void setHostString(String hostString) {
+        this.hostString = hostString;
+    }
+
+    /**
+     * The address is resolved on each call, which needs a DNS lookup when Consul sent a host name.
+     *
+     * @return The resolved {@link InetAddress} of this member, or {@code null} if there is none
+     * @throws java.io.UncheckedIOException if the host name cannot be resolved
+     * @deprecated Use {@link #getHostString()} and resolve the address where it is needed.
+     */
+    @Deprecated(since = "5.2.0", forRemoval = true)
+    @JsonIgnore
+    public InetAddress getAddress() {
+        return ConsulAddresses.resolve(hostString);
+    }
+
+    /**
+     * Sets the address, stored as its host name, or as its IP literal when it has no host name.
+     *
+     * @param address The {@link InetAddress} of this member
+     */
+    @JsonIgnore
     public void setAddress(InetAddress address) {
-        this.address = address;
+        this.hostString = ConsulAddresses.toHostString(address);
     }
 
     /**

--- a/discovery-client/src/main/java/io/micronaut/discovery/consul/client/v1/NodeEntry.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/consul/client/v1/NodeEntry.java
@@ -16,6 +16,7 @@
 package io.micronaut.discovery.consul.client.v1;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import tools.jackson.databind.PropertyNamingStrategies;
 import tools.jackson.databind.annotation.JsonNaming;
@@ -38,7 +39,7 @@ import java.util.Optional;
 public class NodeEntry {
 
     private final String node;
-    private final InetAddress address;
+    private final String hostString;
     private String datacenter;
     private Map<String, String> taggedAddresses;
     private Map<String, String> nodeMetadata;
@@ -46,13 +47,27 @@ public class NodeEntry {
     /**
      * Create a new catalog entry.
      *
-     * @param nodeId  The node ID
-     * @param address The node address
+     * @param nodeId     The node ID
+     * @param hostString The node address as sent by Consul, a host name or an IP literal
+     * @since 5.2.0
      */
     @JsonCreator
-    public NodeEntry(@JsonProperty("Node") String nodeId, @JsonProperty("Address") InetAddress address) {
+    public NodeEntry(@JsonProperty("Node") String nodeId, @JsonProperty("Address") String hostString) {
         this.node = nodeId;
-        this.address = address;
+        this.hostString = hostString;
+    }
+
+    /**
+     * Create a new catalog entry. The address is stored as its host name, or as its IP literal when
+     * it has no host name.
+     *
+     * @param nodeId  The node ID
+     * @param address The node address
+     * @deprecated Use {@link #NodeEntry(String, String)} instead.
+     */
+    @Deprecated(since = "5.2.0", forRemoval = true)
+    public NodeEntry(String nodeId, InetAddress address) {
+        this(nodeId, ConsulAddresses.toHostString(address));
     }
 
     /**
@@ -118,10 +133,27 @@ public class NodeEntry {
     /**
      * See https://www.consul.io/api/catalog.html#address.
      *
-     * @return The node address
+     * @return The node address as sent by Consul, a host name or an IP literal. It is not resolved.
+     * @since 5.2.0
      */
+    @JsonProperty("Address")
+    public String getHostString() {
+        return hostString;
+    }
+
+    /**
+     * See https://www.consul.io/api/catalog.html#address.
+     *
+     * <p>The address is resolved on each call, which needs a DNS lookup when Consul sent a host name.</p>
+     *
+     * @return The resolved node address, or {@code null} if there is none
+     * @throws java.io.UncheckedIOException if the host name cannot be resolved
+     * @deprecated Use {@link #getHostString()} and resolve the address where it is needed.
+     */
+    @Deprecated(since = "5.2.0", forRemoval = true)
+    @JsonIgnore
     public InetAddress getAddress() {
-        return address;
+        return ConsulAddresses.resolve(hostString);
     }
 
     /**

--- a/discovery-client/src/test/groovy/io/micronaut/discovery/consul/ConsulAddressSpec.groovy
+++ b/discovery-client/src/test/groovy/io/micronaut/discovery/consul/ConsulAddressSpec.groovy
@@ -122,4 +122,26 @@ class ConsulAddressSpec extends Specification {
         new NewServiceEntry('test-service').address('10.1.10.12').address.get() == ip
         new NodeEntry('foobar', (String) null).address == null
     }
+
+    void "missing and unresolvable addresses"() {
+        given:
+        InetAddress ip = InetAddress.getByName('10.1.10.12')
+
+        expect: 'a missing address stays missing'
+        new NodeEntry('foobar', (InetAddress) null).hostString == null
+        new ConsulCatalogEntry('foobar', (InetAddress) null, null, null, null, null).address() == null
+        new MemberEntry().tap { hostString = '' }.address == null
+        new NewServiceEntry('test-service').address.empty
+
+        and: 'the setters store the host string'
+        new NewServiceEntry('test-service').tap { address = ip }.hostString.get() == '10.1.10.12'
+        new NewServiceEntry('test-service').tap { hostString = HOST }.hostString.get() == HOST
+
+        when: 'the deprecated accessor has to resolve a host name that does not exist'
+        new NodeEntry('foobar', HOST).address
+
+        then:
+        UncheckedIOException e = thrown()
+        e.message.contains(HOST)
+    }
 }

--- a/discovery-client/src/test/groovy/io/micronaut/discovery/consul/ConsulAddressSpec.groovy
+++ b/discovery-client/src/test/groovy/io/micronaut/discovery/consul/ConsulAddressSpec.groovy
@@ -1,0 +1,125 @@
+package io.micronaut.discovery.consul
+
+import io.micronaut.core.type.Argument
+import io.micronaut.discovery.consul.client.v1.ConsulCatalogEntry
+import io.micronaut.discovery.consul.client.v1.ConsulHealthEntry
+import io.micronaut.discovery.consul.client.v1.MemberEntry
+import io.micronaut.discovery.consul.client.v1.NewServiceEntry
+import io.micronaut.discovery.consul.client.v1.NodeEntry
+import io.micronaut.json.JsonMapper
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+/**
+ * Consul addresses may be host names. They must be read and written as strings, without
+ * depending on how the JSON library handles {@link InetAddress}: Jackson 3.2 only accepts IP literals.
+ */
+@MicronautTest(startApplication = false)
+class ConsulAddressSpec extends Specification {
+
+    // the .invalid top level domain never resolves, so a lookup during deserialization would fail
+    static final String HOST = 'consul-node.invalid'
+
+    @Inject
+    JsonMapper jsonMapper
+
+    void "a health entry with a host name node address is read and written unchanged"() {
+        given:
+        String json = """[{
+  "Node": {"Node": "foobar", "Address": "$HOST", "Datacenter": "dc1"},
+  "Service": {"ID": "redis", "Service": "redis", "Port": 8000},
+  "Checks": []
+}]"""
+
+        when:
+        List<ConsulHealthEntry> entries = jsonMapper.readValue(json, Argument.listOf(ConsulHealthEntry))
+
+        then:
+        entries.size() == 1
+        entries[0].node().address() == HOST
+
+        when: 'the service has no address of its own'
+        ConsulServiceInstance instance = new ConsulServiceInstance(entries[0], 'http')
+
+        then: 'the node host name is used as it is'
+        instance.URI == URI.create("http://$HOST:8000")
+
+        when:
+        String output = jsonMapper.writeValueAsString(entries[0].node())
+
+        then:
+        output.contains(/"Address":"$HOST"/)
+        jsonMapper.readValue(output, ConsulCatalogEntry) == entries[0].node()
+    }
+
+    void "a member with a host name address is read and written unchanged"() {
+        when:
+        MemberEntry member = jsonMapper.readValue(/{"Name": "foobar", "Addr": "$HOST", "Port": 8301, "Status": 1}/, MemberEntry)
+
+        then:
+        member.hostString == HOST
+        member.port == 8301
+
+        when:
+        String output = jsonMapper.writeValueAsString(member)
+
+        then:
+        output.contains(/"Addr":"$HOST"/)
+        !output.contains('"Address"')
+    }
+
+    void "a node entry with a host name address is read and written unchanged"() {
+        when:
+        NodeEntry node = jsonMapper.readValue(/{"Node": "foobar", "Address": "$HOST"}/, NodeEntry)
+
+        then:
+        node.node == 'foobar'
+        node.hostString == HOST
+
+        when:
+        String output = jsonMapper.writeValueAsString(node)
+
+        then:
+        output.contains(/"Address":"$HOST"/)
+        output.count('Address') == 1
+    }
+
+    void "a new service entry keeps a host name address for registration"() {
+        given:
+        NewServiceEntry entry = new NewServiceEntry('test-service').address(HOST).port(8080)
+
+        when:
+        String output = jsonMapper.writeValueAsString(entry)
+
+        then:
+        output.contains(/"Address":"$HOST"/)
+        output.count('Address') == 1
+
+        when:
+        NewServiceEntry read = jsonMapper.readValue(output, NewServiceEntry)
+
+        then:
+        read.hostString.get() == HOST
+        read.port.asInt == 8080
+    }
+
+    void "the InetAddress accessors still work"() {
+        given:
+        InetAddress ip = InetAddress.getByName('10.1.10.12')
+        InetAddress named = InetAddress.getByAddress('consul.example', ip.address)
+
+        expect: 'an address is stored as its host name, or as its IP literal when it has none'
+        new NodeEntry('foobar', ip).hostString == '10.1.10.12'
+        new NodeEntry('foobar', named).hostString == 'consul.example'
+        new ConsulCatalogEntry('foobar', named, null, null, null, null).address() == 'consul.example'
+        new MemberEntry().tap { address = ip }.hostString == '10.1.10.12'
+        new NewServiceEntry('test-service').address(named).hostString.get() == 'consul.example'
+
+        and: 'IP literals resolve without a lookup'
+        new NodeEntry('foobar', '10.1.10.12').address == ip
+        new MemberEntry().tap { hostString = '10.1.10.12' }.address == ip
+        new NewServiceEntry('test-service').address('10.1.10.12').address.get() == ip
+        new NodeEntry('foobar', (String) null).address == null
+    }
+}

--- a/discovery-client/src/test/groovy/io/micronaut/discovery/consul/ConsulCatalogEntrySpec.groovy
+++ b/discovery-client/src/test/groovy/io/micronaut/discovery/consul/ConsulCatalogEntrySpec.groovy
@@ -81,7 +81,7 @@ class ConsulCatalogEntrySpec extends Specification {
 
         then:
         'dc1' == consulCatalogEntry.datacenter()
-        '192.168.10.10' == consulCatalogEntry.address().getHostAddress()
+        '192.168.10.10' == consulCatalogEntry.address()
         [lan: "192.168.10.10", wan: "10.0.10.10"] == consulCatalogEntry.taggedAddresses()
         [somekey: "somevalue"] == consulCatalogEntry.nodeMetadata()
         consulCatalogEntry.service()

--- a/discovery-client/src/test/groovy/io/micronaut/discovery/consul/ConsulClientSpec.groovy
+++ b/discovery-client/src/test/groovy/io/micronaut/discovery/consul/ConsulClientSpec.groovy
@@ -102,7 +102,7 @@ class ConsulClientSpec extends Specification {
     void "test register and deregister catalog entry"() {
         when:
         def url = embeddedServer.getURL()
-        def entry = new ConsulCatalogEntry("test-node", InetAddress.getByName(url.host), null, null, null, null)
+        def entry = new ConsulCatalogEntry("test-node", url.host, null, null, null, null)
         boolean result = Flux.from(client.register(entry)).blockFirst()
 
         then:

--- a/discovery-client/src/test/groovy/io/micronaut/discovery/consul/ConsulHealthEntrySpec.groovy
+++ b/discovery-client/src/test/groovy/io/micronaut/discovery/consul/ConsulHealthEntrySpec.groovy
@@ -98,7 +98,7 @@ class ConsulHealthEntrySpec extends Specification {
         and: 'verify node'
         consulHealthEntry.node()
         'foobar' == consulHealthEntry.node().node()
-        InetAddress.getByName('10.1.10.12') == consulHealthEntry.node().address()
+        '10.1.10.12' == consulHealthEntry.node().address()
         consulHealthEntry.node().datacenter() != null
         'dc1' == consulHealthEntry.node().datacenter()
         [lan: "10.1.10.12", wan: '10.1.10.12'] == consulHealthEntry.node().taggedAddresses()

--- a/discovery-client/src/test/groovy/io/micronaut/discovery/consul/MockConsulServer.groovy
+++ b/discovery-client/src/test/groovy/io/micronaut/discovery/consul/MockConsulServer.groovy
@@ -68,7 +68,8 @@ class MockConsulServer implements ConsulOperations {
 
     final MemberEntry agent = new MemberEntry().tap {
         name = "localhost"
-        address = InetAddress.localHost
+        // a host name, as Consul may send, which Jackson 3.2 no longer reads as an InetAddress
+        hostString = InetAddress.localHost.hostName
         port = 8301
         status = 1
     }
@@ -76,7 +77,7 @@ class MockConsulServer implements ConsulOperations {
     MockConsulServer(EmbeddedServer embeddedServer) {
         newEntries = [:]
         passingReports.clear()
-        nodeEntry = new ConsulCatalogEntry(UUID.randomUUID().toString(), InetAddress.localHost, null, null, null, null)
+        nodeEntry = new ConsulCatalogEntry(UUID.randomUUID().toString(), InetAddress.localHost.hostName, null, null, null, null)
     }
 
     void reset() {

--- a/src/main/docs/guide/breaks.adoc
+++ b/src/main/docs/guide/breaks.adoc
@@ -1,5 +1,16 @@
 This section documents breaking changes between Micronaut Discovery Client versions:
 
+=== Micronaut Discovery Client 5.2.0
+
+Consul may report a node, member or service address as a host name or as an IP address. The Consul client models used to map these addresses to `java.net.InetAddress`, which left the JSON library to resolve host names. Jackson 3.2, managed by Micronaut Framework 5.2, reads an `InetAddress` from IP literals only and no longer performs DNS lookups during deserialization, so responses with host names failed to decode.
+
+The addresses are now kept as the strings Consul sends, and are read and written unchanged by both Jackson Databind and Micronaut Serialization:
+
+* api:discovery.consul.client.v1.ConsulCatalogEntry[]: the `address` component is now a `String`. The constructor taking an `InetAddress` is deprecated.
+* api:discovery.consul.client.v1.NodeEntry[], api:discovery.consul.client.v1.MemberEntry[] and api:discovery.consul.client.v1.AbstractServiceEntry[]: use the new `getHostString()` accessors. The `getAddress()` methods that return an `InetAddress` are deprecated. They resolve the address on each call, which may need a DNS lookup, and throw `UncheckedIOException` when it fails.
+* `AbstractServiceEntry.address(String)` no longer resolves the address, so it no longer throws for a host name that cannot be resolved.
+* A Consul service instance without a service address now uses the node address as Consul reports it, instead of the IP address its host name resolved to.
+
 === Distributed configuration migration note
 
 Distributed configuration via the legacy bootstrap `ConfigurationClient` path is now deprecated. Prefer `micronaut.config.import` with explicit provider URIs such as:


### PR DESCRIPTION
Part of the core 5.2 rollout, micronaut-projects/micronaut-core#13110.

## Problem

Core 5.2 manages Jackson 3.2.2, up from 3.1.4. Jackson 3.2 reads a `java.net.InetAddress` from IP literals only. It no longer does DNS lookups while deserializing. Consul reports node, member and service addresses as host names or IP addresses, and the Consul client models map them to `InetAddress`. So a response with a host name fails:

```
InvalidFormatException: Cannot deserialize value of type java.net.InetAddress from String "<hostname>"
```

On 5.2.x with core 5.2, 15 Consul tests fail this way (`ConsulMockAutoRegistrationSpec` ×9, `ConsulClientSpec`, `ConsulMockHealthStatusSpec`, `TtlHeartbeatSpec`, `CompositeDiscoverySpec`, `ClientScopeSpec`). This is a runtime break in Consul registration, not just in tests. On core 5.1.7 all of them pass.

## Fix

The models keep the address as the string Consul sends, so neither Jackson Databind nor Micronaut Serialization has to resolve it:

- `ConsulCatalogEntry.address` is now a `String`. The `InetAddress` constructor is deprecated.
- `NodeEntry`, `MemberEntry` and `AbstractServiceEntry` gain `getHostString()`, mapped to `Address` / `Addr`. The `InetAddress` getters are deprecated and `@JsonIgnore`d. They resolve on each call and throw `UncheckedIOException` when resolution fails.
- The `InetAddress` setters and constructors store the host name, or the IP literal when there is no host name. This is what Jackson wrote for an `InetAddress`, so the JSON on the wire is unchanged.
- `AbstractServiceEntry.address(String)` no longer resolves the address.
- `ConsulServiceInstance` uses the node address as Consul reports it.

The changes are listed in `breaks.adoc` under 5.2.0.

## Alternatives considered

- **Pin Jackson or re-enable the lookup in core.** Core would keep resolving during deserialization, which is blocking DNS on the event loop, for every consumer.
- **A custom `InetAddress` deserializer in this module.** It keeps the same blocking DNS lookup and still depends on the JSON library.

## Tests

- New `ConsulAddressSpec` (Jackson Databind) and `ConsulAddressSerdeSpec` (Micronaut Serialization, in `discovery-client-tests`). They round-trip host names that do not resolve, and IP literals, without DNS.
- The existing Consul specs and `MockConsulServer` were updated for the string address.
- On core 5.2.0, the Consul tests and `ConsulAddressSerdeSpec` pass and `japiCmp` passes.
- On core 5.1.7, which is still the catalog version on this branch, the Consul tests and `japiCmp` pass: 78 tests, 0 failed. The full `check` passed earlier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
